### PR TITLE
Add CLI11 parsing module

### DIFF
--- a/include/app.hpp
+++ b/include/app.hpp
@@ -1,11 +1,17 @@
 #ifndef AUTOGITHUBPULLMERGE_APP_HPP
 #define AUTOGITHUBPULLMERGE_APP_HPP
 
+#include "cli.hpp"
+
 namespace agpm {
 
 class App {
 public:
   int run(int argc, char **argv);
+  const CliOptions &options() const { return options_; }
+
+private:
+  CliOptions options_;
 };
 
 } // namespace agpm

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -1,0 +1,16 @@
+#ifndef AUTOGITHUBPULLMERGE_CLI_HPP
+#define AUTOGITHUBPULLMERGE_CLI_HPP
+
+#include <string>
+
+namespace agpm {
+
+struct CliOptions {
+  bool verbose = false;
+};
+
+CliOptions parse_cli(int argc, char **argv);
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_CLI_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,10 @@
-add_library(autogithubpullmerge_lib app.cpp)
+find_package(CLI11 CONFIG REQUIRED)
+
+add_library(autogithubpullmerge_lib app.cpp cli.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+
+target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,9 +1,14 @@
 #include "app.hpp"
+#include "cli.hpp"
 #include <iostream>
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
+  options_ = parse_cli(argc, argv);
+  if (options_.verbose) {
+    std::cout << "Verbose mode enabled" << std::endl;
+  }
   std::cout << "Running agpm app" << std::endl;
   return 0;
 }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,0 +1,18 @@
+#include "cli.hpp"
+#include <CLI/CLI.hpp>
+
+namespace agpm {
+
+CliOptions parse_cli(int argc, char **argv) {
+  CLI::App app{"autogithubpullmerge command line"};
+  CliOptions options;
+  app.add_flag("-v,--verbose", options.verbose, "Enable verbose output");
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError &e) {
+    exit(app.exit(e));
+  }
+  return options;
+}
+
+} // namespace agpm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
-#include <iostream>
+#include "app.hpp"
 
 int main(int argc, char **argv) {
-  std::cout << "autogithubpullmerge: starting up" << std::endl;
-  return 0;
+  agpm::App app;
+  return app.run(argc, argv);
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,8 +1,15 @@
 #include "app.hpp"
 #include <cassert>
+#include <vector>
 
 int main() {
   agpm::App app;
-  assert(app.run(0, nullptr) == 0);
+  std::vector<char *> args;
+  char prog[] = "tests";
+  char verbose[] = "--verbose";
+  args.push_back(prog);
+  args.push_back(verbose);
+  assert(app.run(static_cast<int>(args.size()), args.data()) == 0);
+  assert(app.options().verbose);
   return 0;
 }


### PR DESCRIPTION
## Summary
- add `cli` module for argument parsing with CLI11
- expose parsed options via `App`
- hook up CLI parsing in executable
- update unit test to check `--verbose`

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a610e5da883259e8befaba3a6ce07