### PR TITLE
Add config loader with YAML and JSON support

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,0 +1,21 @@
+#ifndef AUTOGITHUBPULLMERGE_CONFIG_HPP
+#define AUTOGITHUBPULLMERGE_CONFIG_HPP
+
+#include <string>
+
+namespace agpm {
+
+/// Application configuration loaded from a YAML or JSON file.
+class Config {
+public:
+  bool verbose() const { return verbose_; }
+  /// Load configuration from the file at `path`.
+  static Config from_file(const std::string &path);
+
+private:
+  bool verbose_ = false;
+};
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_CONFIG_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,12 @@
 find_package(CLI11 CONFIG REQUIRED)
+find_package(yaml-cpp REQUIRED)
+find_package(nlohmann_json REQUIRED)
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
-target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11)
+target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp nlohmann_json::nlohmann_json)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,39 @@
+#include "config.hpp"
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <yaml-cpp/yaml.h>
+
+namespace agpm {
+
+Config Config::from_file(const std::string &path) {
+  Config cfg;
+  auto pos = path.find_last_of('.');
+  if (pos == std::string::npos) {
+    throw std::runtime_error("Unknown config file extension");
+  }
+  std::string ext = path.substr(pos + 1);
+  if (ext == "yaml" || ext == "yml") {
+    YAML::Node node = YAML::LoadFile(path);
+    if (node["verbose"]) {
+      cfg.verbose_ = node["verbose"].as<bool>();
+    }
+  } else if (ext == "json") {
+    std::ifstream f(path);
+    if (!f) {
+      throw std::runtime_error("Failed to open config file");
+    }
+    nlohmann::json j;
+    f >> j;
+    if (j.contains("verbose")) {
+      cfg.verbose_ = j["verbose"].get<bool>();
+    }
+  } else {
+    throw std::runtime_error("Unsupported config format");
+  }
+  return cfg;
+}
+
+} // namespace agpm

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,5 +1,7 @@
 #include "app.hpp"
+#include "config.hpp"
 #include <cassert>
+#include <fstream>
 #include <vector>
 
 int main() {
@@ -11,5 +13,21 @@ int main() {
   args.push_back(verbose);
   assert(app.run(static_cast<int>(args.size()), args.data()) == 0);
   assert(app.options().verbose);
+
+  {
+    std::ofstream yaml("test_config.yaml");
+    yaml << "verbose: true\n";
+    yaml.close();
+    agpm::Config cfg = agpm::Config::from_file("test_config.yaml");
+    assert(cfg.verbose());
+  }
+
+  {
+    std::ofstream json("test_config.json");
+    json << "{\"verbose\": true}";
+    json.close();
+    agpm::Config cfg = agpm::Config::from_file("test_config.json");
+    assert(cfg.verbose());
+  }
   return 0;
 }


### PR DESCRIPTION
## Summary
- add `Config` class to load YAML or JSON files
- link against `yaml-cpp` and `nlohmann_json`
- cover config loading in unit tests

## Testing
- `scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a629b20a88325a93918eee4f4a0aa