### PR TITLE
Add spdlog-based logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - Linux, macOS and Windows install/build scripts
 - Placeholder TUI application in C++20
 - Unit tests using Catch2
+- Logging powered by spdlog with configurable level and output file
 
 ## Building (Linux)
 ```bash

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -7,6 +7,8 @@ namespace agpm {
 
 struct CliOptions {
   bool verbose = false;
+  std::string log_level = "info";
+  std::string log_file;
 };
 
 CliOptions parse_cli(int argc, char **argv);

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -9,11 +9,15 @@ namespace agpm {
 class Config {
 public:
   bool verbose() const { return verbose_; }
+  const std::string &log_level() const { return log_level_; }
+  const std::string &log_file() const { return log_file_; }
   /// Load configuration from the file at `path`.
   static Config from_file(const std::string &path);
 
 private:
   bool verbose_ = false;
+  std::string log_level_ = "info";
+  std::string log_file_;
 };
 
 } // namespace agpm

--- a/include/log.hpp
+++ b/include/log.hpp
@@ -1,0 +1,21 @@
+#ifndef AUTOGITHUBPULLMERGE_LOG_HPP
+#define AUTOGITHUBPULLMERGE_LOG_HPP
+
+#include <memory>
+#include <spdlog/spdlog.h>
+
+namespace agpm {
+
+/** Initialize the global logger with the given level and optional file. */
+void init_logger(spdlog::level::level_enum level = spdlog::level::info,
+                 const std::string &file = "");
+
+/** Convert a string to an spdlog level. */
+spdlog::level::level_enum level_from_string(const std::string &level);
+
+/** Retrieve the global logger instance. */
+std::shared_ptr<spdlog::logger> logger();
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_LOG_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,21 @@
 find_package(CLI11 CONFIG REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
+find_package(spdlog REQUIRED)
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp)
+add_library(autogithubpullmerge_lib
+  app.cpp
+  cli.cpp
+  config.cpp
+  log.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
-target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp nlohmann_json::nlohmann_json)
+target_link_libraries(autogithubpullmerge_lib PUBLIC
+  CLI11::CLI11
+  yaml-cpp
+  nlohmann_json::nlohmann_json
+  spdlog::spdlog)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,15 +1,16 @@
 #include "app.hpp"
 #include "cli.hpp"
-#include <iostream>
+#include "log.hpp"
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
+  init_logger(level_from_string(options_.log_level), options_.log_file);
   if (options_.verbose) {
-    std::cout << "Verbose mode enabled" << std::endl;
+    logger()->info("Verbose mode enabled");
   }
-  std::cout << "Running agpm app" << std::endl;
+  logger()->info("Running agpm app");
   return 0;
 }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -7,6 +7,9 @@ CliOptions parse_cli(int argc, char **argv) {
   CLI::App app{"autogithubpullmerge command line"};
   CliOptions options;
   app.add_flag("-v,--verbose", options.verbose, "Enable verbose output");
+  app.add_option("--log-level", options.log_level,
+                 "Log level (trace, debug, info, warn, error, critical, off)");
+  app.add_option("--log-file", options.log_file, "Log output file");
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError &e) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,6 +20,12 @@ Config Config::from_file(const std::string &path) {
     if (node["verbose"]) {
       cfg.verbose_ = node["verbose"].as<bool>();
     }
+    if (node["log_level"]) {
+      cfg.log_level_ = node["log_level"].as<std::string>();
+    }
+    if (node["log_file"]) {
+      cfg.log_file_ = node["log_file"].as<std::string>();
+    }
   } else if (ext == "json") {
     std::ifstream f(path);
     if (!f) {
@@ -29,6 +35,12 @@ Config Config::from_file(const std::string &path) {
     f >> j;
     if (j.contains("verbose")) {
       cfg.verbose_ = j["verbose"].get<bool>();
+    }
+    if (j.contains("log_level")) {
+      cfg.log_level_ = j["log_level"].get<std::string>();
+    }
+    if (j.contains("log_file")) {
+      cfg.log_file_ = j["log_file"].get<std::string>();
     }
   } else {
     throw std::runtime_error("Unsupported config format");

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,48 @@
+#include "log.hpp"
+#include <spdlog/sinks/basic_file_sink.h>
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace agpm {
+
+static std::shared_ptr<spdlog::logger> global_logger;
+
+spdlog::level::level_enum level_from_string(const std::string &level) {
+  if (level == "trace")
+    return spdlog::level::trace;
+  if (level == "debug")
+    return spdlog::level::debug;
+  if (level == "info")
+    return spdlog::level::info;
+  if (level == "warn")
+    return spdlog::level::warn;
+  if (level == "error")
+    return spdlog::level::err;
+  if (level == "critical")
+    return spdlog::level::critical;
+  if (level == "off")
+    return spdlog::level::off;
+  return spdlog::level::info;
+}
+
+void init_logger(spdlog::level::level_enum level, const std::string &file) {
+  std::vector<spdlog::sink_ptr> sinks;
+  sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+  if (!file.empty()) {
+    sinks.push_back(
+        std::make_shared<spdlog::sinks::basic_file_sink_mt>(file, true));
+  }
+  global_logger =
+      std::make_shared<spdlog::logger>("agpm", begin(sinks), end(sinks));
+  spdlog::register_logger(global_logger);
+  global_logger->set_level(level);
+  global_logger->flush_on(level);
+}
+
+std::shared_ptr<spdlog::logger> logger() {
+  if (!global_logger) {
+    global_logger = spdlog::default_logger();
+  }
+  return global_logger;
+}
+
+} // namespace agpm

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -9,25 +9,40 @@ int main() {
   std::vector<char *> args;
   char prog[] = "tests";
   char verbose[] = "--verbose";
+  char level[] = "--log-level";
+  char level_val[] = "debug";
+  char file_opt[] = "--log-file";
+  char file_val[] = "test.log";
   args.push_back(prog);
   args.push_back(verbose);
+  args.push_back(level);
+  args.push_back(level_val);
+  args.push_back(file_opt);
+  args.push_back(file_val);
   assert(app.run(static_cast<int>(args.size()), args.data()) == 0);
   assert(app.options().verbose);
+  assert(app.options().log_level == "debug");
+  assert(app.options().log_file == "test.log");
 
   {
     std::ofstream yaml("test_config.yaml");
-    yaml << "verbose: true\n";
+    yaml << "verbose: true\nlog_level: debug\nlog_file: cfg.log\n";
     yaml.close();
     agpm::Config cfg = agpm::Config::from_file("test_config.yaml");
     assert(cfg.verbose());
+    assert(cfg.log_level() == "debug");
+    assert(cfg.log_file() == "cfg.log");
   }
 
   {
     std::ofstream json("test_config.json");
-    json << "{\"verbose\": true}";
+    json << "{\"verbose\": true, \"log_level\": \"debug\", \"log_file\": "
+            "\"cfg.log\"}";
     json.close();
     agpm::Config cfg = agpm::Config::from_file("test_config.json");
     assert(cfg.verbose());
+    assert(cfg.log_level() == "debug");
+    assert(cfg.log_file() == "cfg.log");
   }
   return 0;
 }


### PR DESCRIPTION
## Summary
- add `spdlog` to the build system
- introduce `log.hpp`/`log.cpp` wrapper
- expose log level and log file via CLI and config
- update app to use the new logger
- extend tests for logging options

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a70fe73f48325bd27f4d8dd366368