### PR TITLE
Add GitHub client implementation

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -1,0 +1,55 @@
+#ifndef AUTOGITHUBPULLMERGE_GITHUB_CLIENT_HPP
+#define AUTOGITHUBPULLMERGE_GITHUB_CLIENT_HPP
+
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace agpm {
+
+/** Interface for performing HTTP requests. */
+class HttpClient {
+public:
+  virtual ~HttpClient() = default;
+  virtual std::string get(const std::string &url,
+                          const std::vector<std::string> &headers) = 0;
+  virtual std::string put(const std::string &url, const std::string &data,
+                          const std::vector<std::string> &headers) = 0;
+};
+
+/** CURL-based HTTP client implementation. */
+class CurlHttpClient : public HttpClient {
+public:
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override;
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override;
+};
+
+/// Representation of a GitHub pull request.
+struct PullRequest {
+  int number;
+  std::string title;
+};
+
+/** Simple GitHub API client. */
+class GitHubClient {
+public:
+  explicit GitHubClient(std::string token,
+                        std::unique_ptr<HttpClient> http = nullptr);
+
+  std::vector<PullRequest> list_pull_requests(const std::string &owner,
+                                              const std::string &repo);
+
+  bool merge_pull_request(const std::string &owner, const std::string &repo,
+                          int pr_number);
+
+private:
+  std::string token_;
+  std::unique_ptr<HttpClient> http_;
+};
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_GITHUB_CLIENT_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,13 @@
 find_package(CLI11 CONFIG REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
+find_package(CURL REQUIRED)
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp github_client.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
-target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp nlohmann_json::nlohmann_json)
+target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp nlohmann_json::nlohmann_json CURL::libcurl)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -1,0 +1,99 @@
+#include "github_client.hpp"
+#include <curl/curl.h>
+#include <stdexcept>
+
+namespace agpm {
+
+static size_t write_callback(void *contents, size_t size, size_t nmemb,
+                             void *userp) {
+  size_t total = size * nmemb;
+  std::string *s = static_cast<std::string *>(userp);
+  s->append(static_cast<char *>(contents), total);
+  return total;
+}
+
+std::string CurlHttpClient::get(const std::string &url,
+                                const std::vector<std::string> &headers) {
+  CURL *curl = curl_easy_init();
+  if (!curl) {
+    throw std::runtime_error("Failed to init curl");
+  }
+  std::string response;
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+  struct curl_slist *header_list = nullptr;
+  for (const auto &h : headers) {
+    header_list = curl_slist_append(header_list, h.c_str());
+  }
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+  CURLcode res = curl_easy_perform(curl);
+  curl_slist_free_all(header_list);
+  curl_easy_cleanup(curl);
+  if (res != CURLE_OK) {
+    throw std::runtime_error("curl GET failed");
+  }
+  return response;
+}
+
+std::string CurlHttpClient::put(const std::string &url, const std::string &data,
+                                const std::vector<std::string> &headers) {
+  CURL *curl = curl_easy_init();
+  if (!curl) {
+    throw std::runtime_error("Failed to init curl");
+  }
+  std::string response;
+  curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+  curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data.c_str());
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
+  struct curl_slist *header_list = nullptr;
+  for (const auto &h : headers) {
+    header_list = curl_slist_append(header_list, h.c_str());
+  }
+  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+  CURLcode res = curl_easy_perform(curl);
+  curl_slist_free_all(header_list);
+  curl_easy_cleanup(curl);
+  if (res != CURLE_OK) {
+    throw std::runtime_error("curl PUT failed");
+  }
+  return response;
+}
+
+GitHubClient::GitHubClient(std::string token, std::unique_ptr<HttpClient> http)
+    : token_(std::move(token)),
+      http_(http ? std::move(http) : std::make_unique<CurlHttpClient>()) {}
+
+std::vector<PullRequest>
+GitHubClient::list_pull_requests(const std::string &owner,
+                                 const std::string &repo) {
+  std::string url =
+      "https://api.github.com/repos/" + owner + "/" + repo + "/pulls";
+  std::vector<std::string> headers = {"Authorization: token " + token_,
+                                      "Accept: application/vnd.github+json"};
+  std::string resp = http_->get(url, headers);
+  nlohmann::json j = nlohmann::json::parse(resp);
+  std::vector<PullRequest> prs;
+  for (const auto &item : j) {
+    PullRequest pr;
+    pr.number = item["number"].get<int>();
+    pr.title = item["title"].get<std::string>();
+    prs.push_back(pr);
+  }
+  return prs;
+}
+
+bool GitHubClient::merge_pull_request(const std::string &owner,
+                                      const std::string &repo, int pr_number) {
+  std::string url = "https://api.github.com/repos/" + owner + "/" + repo +
+                    "/pulls/" + std::to_string(pr_number) + "/merge";
+  std::vector<std::string> headers = {"Authorization: token " + token_,
+                                      "Accept: application/vnd.github+json"};
+  std::string resp = http_->put(url, "{}", headers);
+  nlohmann::json j = nlohmann::json::parse(resp);
+  return j.contains("merged") && j["merged"].get<bool>();
+}
+
+} // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,7 @@
-add_executable(tests test_main.cpp)
+add_executable(test_main test_main.cpp)
+target_link_libraries(test_main PRIVATE autogithubpullmerge_lib)
+add_test(NAME main_test COMMAND test_main)
 
-target_link_libraries(tests PRIVATE autogithubpullmerge_lib)
-
-add_test(NAME main_test COMMAND tests)
+add_executable(test_github_client test_github_client.cpp)
+target_link_libraries(test_github_client PRIVATE autogithubpullmerge_lib)
+add_test(NAME github_client_test COMMAND test_github_client)

--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -1,0 +1,49 @@
+#include "github_client.hpp"
+#include <cassert>
+#include <string>
+
+using namespace agpm;
+
+class MockHttpClient : public HttpClient {
+public:
+  std::string last_url;
+  std::string last_method;
+  std::string response;
+
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_url = url;
+    last_method = "GET";
+    return response;
+  }
+
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)data;
+    (void)headers;
+    last_url = url;
+    last_method = "PUT";
+    return response;
+  }
+};
+
+int main() {
+  // Test listing pull requests
+  auto mock = std::make_unique<MockHttpClient>();
+  mock->response = "[{\"number\":1,\"title\":\"Test\"}]";
+  GitHubClient client("token", std::unique_ptr<HttpClient>(mock.release()));
+  auto prs = client.list_pull_requests("owner", "repo");
+  assert(prs.size() == 1);
+  assert(prs[0].number == 1);
+  assert(prs[0].title == "Test");
+
+  // Test merging pull requests
+  auto mock2 = std::make_unique<MockHttpClient>();
+  mock2->response = "{\"merged\":true}";
+  GitHubClient client2("token", std::unique_ptr<HttpClient>(mock2.release()));
+  bool merged = client2.merge_pull_request("owner", "repo", 1);
+  assert(merged);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement `GitHubClient` with simple curl-based HTTP wrapper
- list and merge pull requests using the GitHub API
- unit test GitHub client via a mock HTTP client
- link curl and add test executable in CMake

## Testing
- `scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a7aa283708325ae1c6d3a6b63953a