### PR TITLE
Add unit tests for CLI, config and GitHub client

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,18 @@ add_executable(test_main test_main.cpp)
 target_link_libraries(test_main PRIVATE autogithubpullmerge_lib)
 add_test(NAME main_test COMMAND test_main)
 
+add_executable(test_cli test_cli.cpp)
+target_link_libraries(test_cli PRIVATE autogithubpullmerge_lib)
+add_test(NAME cli_test COMMAND test_cli)
+
+add_executable(test_config test_config.cpp)
+target_link_libraries(test_config PRIVATE autogithubpullmerge_lib)
+add_test(NAME config_test COMMAND test_config)
+
 add_executable(test_github_client test_github_client.cpp)
 target_link_libraries(test_github_client PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_client_test COMMAND test_github_client)
+
+add_executable(test_github_client_behavior test_github_client_behavior.cpp)
+target_link_libraries(test_github_client_behavior PRIVATE autogithubpullmerge_lib)
+add_test(NAME github_client_behavior_test COMMAND test_github_client_behavior)

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -1,0 +1,15 @@
+#include "cli.hpp"
+#include <cassert>
+
+int main() {
+  char prog[] = "prog";
+  char verbose[] = "--verbose";
+  char *argv1[] = {prog, verbose};
+  agpm::CliOptions opts = agpm::parse_cli(2, argv1);
+  assert(opts.verbose);
+
+  char *argv2[] = {prog};
+  agpm::CliOptions opts2 = agpm::parse_cli(1, argv2);
+  assert(!opts2.verbose);
+  return 0;
+}

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,25 @@
+#include "config.hpp"
+#include <cassert>
+#include <fstream>
+
+int main() {
+  // YAML config enabling verbose
+  {
+    std::ofstream f("cfg.yaml");
+    f << "verbose: true\n";
+    f.close();
+  }
+  agpm::Config yaml_cfg = agpm::Config::from_file("cfg.yaml");
+  assert(yaml_cfg.verbose());
+
+  // JSON config disabling verbose
+  {
+    std::ofstream f("cfg.json");
+    f << "{\"verbose\": false}";
+    f.close();
+  }
+  agpm::Config json_cfg = agpm::Config::from_file("cfg.json");
+  assert(!json_cfg.verbose());
+
+  return 0;
+}

--- a/tests/test_github_client_behavior.cpp
+++ b/tests/test_github_client_behavior.cpp
@@ -1,0 +1,46 @@
+#include "github_client.hpp"
+#include <cassert>
+#include <string>
+
+using namespace agpm;
+
+class DummyHttpClient : public HttpClient {
+public:
+  std::string last_url;
+  std::string last_method;
+  std::string response;
+
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_url = url;
+    last_method = "GET";
+    return response;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)data;
+    (void)headers;
+    last_url = url;
+    last_method = "PUT";
+    return response;
+  }
+};
+
+int main() {
+  auto dummy = std::make_unique<DummyHttpClient>();
+  dummy->response = "[{\"number\":2,\"title\":\"Another\"}]";
+  GitHubClient client("token", std::unique_ptr<HttpClient>(dummy.release()));
+  auto prs = client.list_pull_requests("octocat", "hello");
+  assert(prs.size() == 1);
+  assert(prs[0].number == 2);
+  assert(prs[0].title == "Another");
+
+  auto dummy2 = std::make_unique<DummyHttpClient>();
+  dummy2->response = "{\"merged\":false}";
+  GitHubClient client2("token", std::unique_ptr<HttpClient>(dummy2.release()));
+  bool merged = client2.merge_pull_request("octocat", "hello", 5);
+  assert(!merged);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add dedicated tests for CLI argument parsing
- add dedicated tests for configuration loading
- add extended GitHub client behaviour tests
- update test CMake configuration

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a85c700488325804726c29514eb74