### PR TITLE
Add ConfigManager for YAML/JSON config loading

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -11,6 +11,9 @@ public:
   /** Check whether verbose output is enabled. */
   bool verbose() const { return verbose_; }
 
+  /// Set verbose output mode.
+  void set_verbose(bool verbose) { verbose_ = verbose; }
+
   /// Load configuration from the file at `path`.
   static Config from_file(const std::string &path);
 

--- a/include/config_manager.hpp
+++ b/include/config_manager.hpp
@@ -1,0 +1,18 @@
+#ifndef AUTOGITHUBPULLMERGE_CONFIG_MANAGER_HPP
+#define AUTOGITHUBPULLMERGE_CONFIG_MANAGER_HPP
+
+#include "config.hpp"
+#include <string>
+
+namespace agpm {
+
+/// Utility class for loading configuration files.
+class ConfigManager {
+public:
+  /// Load a configuration from a YAML or JSON file.
+  Config load(const std::string &path) const;
+};
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_CONFIG_MANAGER_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp github_client.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -1,20 +1,19 @@
-#include "config.hpp"
+#include "config_manager.hpp"
 #include <fstream>
 #include <stdexcept>
-#include <string>
 
 #include <nlohmann/json.hpp>
 #include <yaml-cpp/yaml.h>
 
 namespace agpm {
 
-Config Config::from_file(const std::string &path) {
-  Config cfg;
+Config ConfigManager::load(const std::string &path) const {
   auto pos = path.find_last_of('.');
   if (pos == std::string::npos) {
     throw std::runtime_error("Unknown config file extension");
   }
   std::string ext = path.substr(pos + 1);
+  Config cfg;
   if (ext == "yaml" || ext == "yml") {
     YAML::Node node = YAML::LoadFile(path);
     if (node["verbose"]) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,10 @@ add_executable(test_config test_config.cpp)
 target_link_libraries(test_config PRIVATE autogithubpullmerge_lib)
 add_test(NAME config_test COMMAND test_config)
 
+add_executable(test_config_manager test_config_manager.cpp)
+target_link_libraries(test_config_manager PRIVATE autogithubpullmerge_lib)
+add_test(NAME config_manager_test COMMAND test_config_manager)
+
 add_executable(test_github_client test_github_client.cpp)
 target_link_libraries(test_github_client PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_client_test COMMAND test_github_client)

--- a/tests/test_config_manager.cpp
+++ b/tests/test_config_manager.cpp
@@ -1,0 +1,24 @@
+#include "config_manager.hpp"
+#include <cassert>
+#include <fstream>
+
+int main() {
+  agpm::ConfigManager mgr;
+  {
+    std::ofstream f("cfg.yaml");
+    f << "verbose: true\n";
+    f.close();
+  }
+  agpm::Config yaml_cfg = mgr.load("cfg.yaml");
+  assert(yaml_cfg.verbose());
+
+  {
+    std::ofstream f("cfg.json");
+    f << "{\"verbose\": false}";
+    f.close();
+  }
+  agpm::Config json_cfg = mgr.load("cfg.json");
+  assert(!json_cfg.verbose());
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement `ConfigManager` class to load YAML and JSON configuration files
- expose setter for verbose flag in `Config`
- compile new files and include new tests
- test YAML/JSON loading via `ConfigManager`

## Testing
- `cmake ..`
- `cmake --build . -- -j$(nproc)`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_688a878a923c83259abba0ce5cd48f28