### PR TITLE
Add SQLite history wrapper with export and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autogithubpullmerge
+#autogithubpullmerge
 
 A cross-platform tool to manage and monitor GitHub pull requests from a terminal user interface.
 
@@ -7,6 +7,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - Linux, macOS and Windows install/build scripts
 - Placeholder TUI application in C++20
 - Unit tests using Catch2
+- SQLite-based history storage with CSV/JSON export
 
 ## Building (Linux)
 ```bash

--- a/include/history.hpp
+++ b/include/history.hpp
@@ -1,0 +1,40 @@
+#ifndef AUTOGITHUBPULLMERGE_HISTORY_HPP
+#define AUTOGITHUBPULLMERGE_HISTORY_HPP
+
+#include <nlohmann/json.hpp>
+#include <sqlite3.h>
+#include <string>
+
+namespace agpm {
+
+/** Simple wrapper around SQLite for storing pull request history. */
+class PullRequestHistory {
+public:
+  /** Construct and open the database at `db_path`. */
+  explicit PullRequestHistory(const std::string &db_path);
+
+  /// Destructor closes the database connection.
+  ~PullRequestHistory();
+
+  /**
+   * Insert a pull request entry.
+   *
+   * @param number Pull request number
+   * @param title Pull request title
+   * @param merged Whether the pull request was merged
+   */
+  void insert(int number, const std::string &title, bool merged);
+
+  /// Export the database contents to a CSV file.
+  void export_csv(const std::string &path);
+
+  /// Export the database contents to a JSON file.
+  void export_json(const std::string &path);
+
+private:
+  sqlite3 *db_ = nullptr;
+};
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_HISTORY_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,12 +2,16 @@ find_package(CLI11 CONFIG REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
+find_package(SQLite3 REQUIRED)
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp github_client.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp github_client.cpp
+                                  history.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
-target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp nlohmann_json::nlohmann_json CURL::libcurl)
+target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp
+                                              nlohmann_json::nlohmann_json
+                                              CURL::libcurl SQLite::SQLite3)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,0 +1,93 @@
+#include "history.hpp"
+#include <fstream>
+#include <stdexcept>
+
+namespace agpm {
+
+PullRequestHistory::PullRequestHistory(const std::string &db_path) {
+  if (sqlite3_open(db_path.c_str(), &db_) != SQLITE_OK) {
+    throw std::runtime_error("Failed to open database");
+  }
+  const char *sql = "CREATE TABLE IF NOT EXISTS pull_requests("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                    "number INTEGER, title TEXT, merged INTEGER);";
+  char *err = nullptr;
+  if (sqlite3_exec(db_, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+    std::string msg = err ? err : "";
+    sqlite3_free(err);
+    throw std::runtime_error("Failed to create table: " + msg);
+  }
+}
+
+PullRequestHistory::~PullRequestHistory() {
+  if (db_) {
+    sqlite3_close(db_);
+  }
+}
+
+void PullRequestHistory::insert(int number, const std::string &title,
+                                bool merged) {
+  sqlite3_stmt *stmt = nullptr;
+  const char *sql =
+      "INSERT INTO pull_requests(number,title,merged) VALUES(?,?,?)";
+  if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    throw std::runtime_error("Failed to prepare insert");
+  }
+  sqlite3_bind_int(stmt, 1, number);
+  sqlite3_bind_text(stmt, 2, title.c_str(), -1, SQLITE_TRANSIENT);
+  sqlite3_bind_int(stmt, 3, merged ? 1 : 0);
+  if (sqlite3_step(stmt) != SQLITE_DONE) {
+    sqlite3_finalize(stmt);
+    throw std::runtime_error("Failed to execute insert");
+  }
+  sqlite3_finalize(stmt);
+}
+
+void PullRequestHistory::export_csv(const std::string &path) {
+  std::ofstream out(path);
+  if (!out) {
+    throw std::runtime_error("Failed to open CSV file");
+  }
+  out << "number,title,merged\n";
+  const char *sql = "SELECT number,title,merged FROM pull_requests";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    throw std::runtime_error("Failed to query database");
+  }
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    int number = sqlite3_column_int(stmt, 0);
+    const unsigned char *title = sqlite3_column_text(stmt, 1);
+    int merged = sqlite3_column_int(stmt, 2);
+    out << number << ",\""
+        << (title ? reinterpret_cast<const char *>(title) : "") << "\","
+        << merged << "\n";
+  }
+  sqlite3_finalize(stmt);
+}
+
+void PullRequestHistory::export_json(const std::string &path) {
+  nlohmann::json j = nlohmann::json::array();
+  const char *sql = "SELECT number,title,merged FROM pull_requests";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    throw std::runtime_error("Failed to query database");
+  }
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    int number = sqlite3_column_int(stmt, 0);
+    const unsigned char *title = sqlite3_column_text(stmt, 1);
+    int merged = sqlite3_column_int(stmt, 2);
+    nlohmann::json item;
+    item["number"] = number;
+    item["title"] = title ? reinterpret_cast<const char *>(title) : "";
+    item["merged"] = merged != 0;
+    j.push_back(item);
+  }
+  sqlite3_finalize(stmt);
+  std::ofstream out(path);
+  if (!out) {
+    throw std::runtime_error("Failed to open JSON file");
+  }
+  out << j.dump(2);
+}
+
+} // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,7 @@ add_test(NAME github_client_test COMMAND test_github_client)
 add_executable(test_github_client_behavior test_github_client_behavior.cpp)
 target_link_libraries(test_github_client_behavior PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_client_behavior_test COMMAND test_github_client_behavior)
+
+add_executable(test_history test_history.cpp)
+target_link_libraries(test_history PRIVATE autogithubpullmerge_lib)
+add_test(NAME history_test COMMAND test_history)

--- a/tests/test_history.cpp
+++ b/tests/test_history.cpp
@@ -1,0 +1,36 @@
+#include "history.hpp"
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+
+using namespace agpm;
+
+int main() {
+  PullRequestHistory hist("test_history.db");
+  hist.insert(1, "Test PR", true);
+  hist.export_csv("out.csv");
+  hist.export_json("out.json");
+
+  std::ifstream csv("out.csv");
+  std::string line;
+  std::getline(csv, line);
+  assert(line == "number,title,merged");
+  std::getline(csv, line);
+  assert(line.find("1") != std::string::npos);
+  assert(line.find("Test PR") != std::string::npos);
+  csv.close();
+
+  std::ifstream js("out.json");
+  nlohmann::json j;
+  js >> j;
+  assert(j.is_array());
+  assert(j.size() == 1);
+  assert(j[0]["number"] == 1);
+  assert(j[0]["title"] == "Test PR");
+  assert(j[0]["merged"] == true);
+
+  std::remove("test_history.db");
+  std::remove("out.csv");
+  std::remove("out.json");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `PullRequestHistory` wrapper using SQLite for storing PR history
- support exporting stored entries to CSV and JSON
- update build system and README to reflect new feature
- add unit test for the new history component

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a8795a8fc83259e7f373ca38d4113