### PR TITLE
Add --config flag to CLI

### DIFF
--- a/include/app.hpp
+++ b/include/app.hpp
@@ -2,6 +2,7 @@
 #define AUTOGITHUBPULLMERGE_APP_HPP
 
 #include "cli.hpp"
+#include "config.hpp"
 
 namespace agpm {
 
@@ -20,8 +21,12 @@ public:
   /** Retrieve the parsed command line options. */
   const CliOptions &options() const { return options_; }
 
+  /** Retrieve the loaded configuration. */
+  const Config &config() const { return config_; }
+
 private:
   CliOptions options_;
+  Config config_;
 };
 
 } // namespace agpm

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -7,7 +7,8 @@ namespace agpm {
 
 /** Parsed command line options. */
 struct CliOptions {
-  bool verbose = false; ///< Enables verbose output
+  bool verbose = false;    ///< Enables verbose output
+  std::string config_file; ///< Optional path to configuration file
 };
 
 /**

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,11 +1,15 @@
 #include "app.hpp"
 #include "cli.hpp"
+#include "config.hpp"
 #include <iostream>
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
+  if (!options_.config_file.empty()) {
+    config_ = Config::from_file(options_.config_file);
+  }
   if (options_.verbose) {
     std::cout << "Verbose mode enabled" << std::endl;
   }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -7,6 +7,8 @@ CliOptions parse_cli(int argc, char **argv) {
   CLI::App app{"autogithubpullmerge command line"};
   CliOptions options;
   app.add_flag("-v,--verbose", options.verbose, "Enable verbose output");
+  app.add_option("--config", options.config_file, "Path to configuration file")
+      ->type_name("FILE");
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError &e) {

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -11,5 +11,11 @@ int main() {
   char *argv2[] = {prog};
   agpm::CliOptions opts2 = agpm::parse_cli(1, argv2);
   assert(!opts2.verbose);
+
+  char config_flag[] = "--config";
+  char file[] = "cfg.yaml";
+  char *argv3[] = {prog, config_flag, file};
+  agpm::CliOptions opts3 = agpm::parse_cli(3, argv3);
+  assert(opts3.config_file == "cfg.yaml");
   return 0;
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -14,6 +14,21 @@ int main() {
   assert(app.run(static_cast<int>(args.size()), args.data()) == 0);
   assert(app.options().verbose);
 
+  agpm::App app_cfg;
+  std::ofstream cfg("run_config.yaml");
+  cfg << "verbose: true\n";
+  cfg.close();
+  std::vector<char *> args_cfg;
+  char prog2[] = "tests";
+  char config_flag[] = "--config";
+  char cfg_file[] = "run_config.yaml";
+  args_cfg.push_back(prog2);
+  args_cfg.push_back(config_flag);
+  args_cfg.push_back(cfg_file);
+  assert(app_cfg.run(static_cast<int>(args_cfg.size()), args_cfg.data()) == 0);
+  assert(app_cfg.options().config_file == "run_config.yaml");
+  assert(app_cfg.config().verbose());
+
   {
     std::ofstream yaml("test_config.yaml");
     yaml << "verbose: true\n";


### PR DESCRIPTION
## Summary
- extend `CliOptions` with `config_file`
- parse `--config <file>` via CLI11
- load configuration file in `App::run`
- expose loaded `Config` from `App`
- update CLI and main unit tests for new flag

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688adb2b53148325aed9e63d203da833