### PR TITLE
Add spdlog logging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - Placeholder TUI application in C++20
 - Unit tests using Catch2
 - SQLite-based history storage with CSV/JSON export
+- Configurable logging with spdlog
 
 ## Building (Linux)
 ```bash
@@ -22,4 +23,13 @@ repository root to generate docs in `docs/build`:
 
 ```bash
 doxygen docs/Doxyfile
+```
+
+## Logging
+
+Use the `--log-level` option to control verbosity. Valid levels include `trace`,
+`debug`, `info`, `warning`, `error`, `critical` and `off`:
+
+```bash
+./autogithubpullmerge --log-level debug
 ```

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -7,7 +7,8 @@ namespace agpm {
 
 /** Parsed command line options. */
 struct CliOptions {
-  bool verbose = false; ///< Enables verbose output
+  bool verbose = false;           ///< Enables verbose output
+  std::string log_level = "info"; ///< Logging verbosity level
 };
 
 /**

--- a/include/log.hpp
+++ b/include/log.hpp
@@ -1,0 +1,13 @@
+#ifndef AUTOGITHUBPULLMERGE_LOG_HPP
+#define AUTOGITHUBPULLMERGE_LOG_HPP
+
+#include <spdlog/spdlog.h>
+
+namespace agpm {
+
+/** Initialize the global logger with the given level. */
+void init_logging(spdlog::level::level_enum level);
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_LOG_HPP

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 sudo apt-get update
-sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libsqlite3-dev
+sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libsqlite3-dev libspdlog-dev

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-brew install cmake git curl sqlite3
+brew install cmake git curl sqlite3 spdlog

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -1,1 +1,1 @@
-choco install cmake git curl sqlite
+choco install cmake git curl sqlite spdlog

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,15 +3,17 @@ find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
 find_package(SQLite3 REQUIRED)
+find_package(spdlog REQUIRED)
 
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp history.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp history.cpp log.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp
                                               nlohmann_json::nlohmann_json
-                                              CURL::libcurl SQLite::SQLite3)
+                                              CURL::libcurl SQLite::SQLite3
+                                              spdlog::spdlog)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,11 +1,15 @@
 #include "app.hpp"
 #include "cli.hpp"
+#include "log.hpp"
 #include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
+  spdlog::level::level_enum lvl = spdlog::level::from_str(options_.log_level);
+  init_logging(lvl);
   if (options_.verbose) {
     std::cout << "Verbose mode enabled" << std::endl;
   }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -7,6 +7,9 @@ CliOptions parse_cli(int argc, char **argv) {
   CLI::App app{"autogithubpullmerge command line"};
   CliOptions options;
   app.add_flag("-v,--verbose", options.verbose, "Enable verbose output");
+  app.add_option(
+      "--log-level", options.log_level,
+      "Set log level (trace, debug, info, warning, error, critical, off)");
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError &e) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,13 @@
+#include "log.hpp"
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace agpm {
+
+void init_logging(spdlog::level::level_enum level) {
+  auto console = spdlog::stdout_color_mt("console");
+  console->set_level(level);
+  spdlog::set_default_logger(console);
+  spdlog::set_level(level);
+}
+
+} // namespace agpm

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -8,8 +8,15 @@ int main() {
   agpm::CliOptions opts = agpm::parse_cli(2, argv1);
   assert(opts.verbose);
 
+  char loglevel[] = "--log-level";
+  char debug[] = "debug";
+  char *argv2a[] = {prog, loglevel, debug};
+  agpm::CliOptions opts_level = agpm::parse_cli(3, argv2a);
+  assert(opts_level.log_level == "debug");
+
   char *argv2[] = {prog};
   agpm::CliOptions opts2 = agpm::parse_cli(1, argv2);
   assert(!opts2.verbose);
+  assert(opts2.log_level == "info");
   return 0;
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -9,10 +9,15 @@ int main() {
   std::vector<char *> args;
   char prog[] = "tests";
   char verbose[] = "--verbose";
+  char level_flag[] = "--log-level";
+  char level_val[] = "warning";
   args.push_back(prog);
   args.push_back(verbose);
+  args.push_back(level_flag);
+  args.push_back(level_val);
   assert(app.run(static_cast<int>(args.size()), args.data()) == 0);
   assert(app.options().verbose);
+  assert(app.options().log_level == "warning");
 
   {
     std::ofstream yaml("test_config.yaml");


### PR DESCRIPTION
## Summary
- install spdlog in build scripts
- link spdlog in library build
- add `--log-level` CLI option
- initialize logging in `App::run`
- document logging in README

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688adb290bd8832585004e3b058693e7