### PR TITLE
Add spdlog based logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - Placeholder TUI application in C++20
 - Unit tests using Catch2
 - SQLite-based history storage with CSV/JSON export
+- Configurable logging with `--log-level`
 
 ## Building (Linux)
 ```bash
@@ -23,3 +24,8 @@ repository root to generate docs in `docs/build`:
 ```bash
 doxygen docs/Doxyfile
 ```
+
+## Logging
+
+Use the `--log-level` option to control verbosity. Valid levels include
+`trace`, `debug`, `info`, `warn`, `error`, `critical` and `off`.

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -7,8 +7,9 @@ namespace agpm {
 
 /** Parsed command line options. */
 struct CliOptions {
-  bool verbose = false;    ///< Enables verbose output
-  std::string config_file; ///< Optional path to configuration file
+  bool verbose = false;           ///< Enables verbose output
+  std::string config_file;        ///< Optional path to configuration file
+  std::string log_level = "info"; ///< Logging verbosity level
 };
 
 /**

--- a/include/log.hpp
+++ b/include/log.hpp
@@ -1,0 +1,13 @@
+#ifndef AUTOGITHUBPULLMERGE_LOG_HPP
+#define AUTOGITHUBPULLMERGE_LOG_HPP
+
+#include <spdlog/spdlog.h>
+
+namespace agpm {
+
+/** Initialize global logger with the given level. */
+void init_logger(spdlog::level::level_enum level);
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_LOG_HPP

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -e
 sudo apt-get update
-sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libsqlite3-dev
+sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libsqlite3-dev libspdlog-dev

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 set -e
-brew install cmake git curl sqlite3
+brew install cmake git curl sqlite3 spdlog

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -1,1 +1,1 @@
-choco install cmake git curl sqlite
+choco install cmake git curl sqlite spdlog

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,15 +3,17 @@ find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
 find_package(SQLite3 REQUIRED)
+find_package(spdlog REQUIRED)
 
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp history.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp history.cpp log.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp
                                               nlohmann_json::nlohmann_json
-                                              CURL::libcurl SQLite::SQLite3)
+                                              CURL::libcurl SQLite::SQLite3
+                                              spdlog::spdlog)
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,12 +1,21 @@
 #include "app.hpp"
 #include "cli.hpp"
 #include "config.hpp"
+#include "log.hpp"
 #include <iostream>
+#include <spdlog/spdlog.h>
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
+  spdlog::level::level_enum lvl = spdlog::level::info;
+  try {
+    lvl = spdlog::level::from_str(options_.log_level);
+  } catch (const spdlog::spdlog_ex &) {
+    // keep default
+  }
+  init_logger(lvl);
   if (!options_.config_file.empty()) {
     config_ = Config::from_file(options_.config_file);
   }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -9,6 +9,11 @@ CliOptions parse_cli(int argc, char **argv) {
   app.add_flag("-v,--verbose", options.verbose, "Enable verbose output");
   app.add_option("--config", options.config_file, "Path to configuration file")
       ->type_name("FILE");
+  app.add_option(
+         "--log-level", options.log_level,
+         "Set logging level (trace, debug, info, warn, error, critical, off)")
+      ->type_name("LEVEL")
+      ->default_val("info");
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError &e) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,15 @@
+#include "log.hpp"
+#include <spdlog/sinks/stdout_color_sinks.h>
+
+namespace agpm {
+
+void init_logger(spdlog::level::level_enum level) {
+  auto logger = spdlog::get("agpm");
+  if (!logger) {
+    logger = spdlog::stdout_color_mt("agpm");
+    spdlog::set_default_logger(logger);
+  }
+  logger->set_level(level);
+}
+
+} // namespace agpm

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -17,5 +17,15 @@ int main() {
   char *argv3[] = {prog, config_flag, file};
   agpm::CliOptions opts3 = agpm::parse_cli(3, argv3);
   assert(opts3.config_file == "cfg.yaml");
+
+  char log_flag[] = "--log-level";
+  char debug_lvl[] = "debug";
+  char *argv4[] = {prog, log_flag, debug_lvl};
+  agpm::CliOptions opts4 = agpm::parse_cli(3, argv4);
+  assert(opts4.log_level == "debug");
+
+  char *argv5[] = {prog};
+  agpm::CliOptions opts5 = agpm::parse_cli(1, argv5);
+  assert(opts5.log_level == "info");
   return 0;
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -29,6 +29,17 @@ int main() {
   assert(app_cfg.options().config_file == "run_config.yaml");
   assert(app_cfg.config().verbose());
 
+  agpm::App log_app;
+  std::vector<char *> args_log;
+  char prog3[] = "tests";
+  char log_flag[] = "--log-level";
+  char warn_lvl[] = "warn";
+  args_log.push_back(prog3);
+  args_log.push_back(log_flag);
+  args_log.push_back(warn_lvl);
+  assert(log_app.run(static_cast<int>(args_log.size()), args_log.data()) == 0);
+  assert(log_app.options().log_level == "warn");
+
   {
     std::ofstream yaml("test_config.yaml");
     yaml << "verbose: true\n";


### PR DESCRIPTION
## Summary
- add spdlog dependency and install steps
- wrap spdlog setup in a new log module
- expose `--log-level` CLI option
- initialize logging in `App::run`
- document logging usage

## Testing
- `./scripts/install_linux.sh`
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688aef32b99483258128140c70bfa51d