### PR TITLE
Add ncurses TUI module with tests

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -1,0 +1,27 @@
+#ifndef AUTOGITHUBPULLMERGE_TUI_HPP
+#define AUTOGITHUBPULLMERGE_TUI_HPP
+
+#include "github_client.hpp"
+#include <vector>
+
+namespace agpm {
+
+/**
+ * Minimal ncurses-based text user interface.
+ */
+class Tui {
+public:
+  /// Initialize curses.
+  Tui();
+  /// End curses on destruction.
+  ~Tui();
+
+  /** Run the UI displaying a list of pull requests.
+   * If the list is empty the UI initializes and exits immediately.
+   */
+  int run(const std::vector<PullRequest> &prs);
+};
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_TUI_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,16 +4,17 @@ find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
 find_package(SQLite3 REQUIRED)
 find_package(spdlog REQUIRED)
+find_package(Curses REQUIRED)
 
 
-add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp history.cpp log.cpp)
+add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cpp github_client.cpp history.cpp log.cpp tui.cpp)
 
-target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CURSES_INCLUDE_DIR})
 
 target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp
                                               nlohmann_json::nlohmann_json
                                               CURL::libcurl SQLite::SQLite3
-                                              spdlog::spdlog)
+                                              spdlog::spdlog ${CURSES_LIBRARIES})
 
 add_executable(autogithubpullmerge main.cpp)
 target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,8 +1,11 @@
 #include "app.hpp"
 #include "cli.hpp"
 #include "config.hpp"
+#include "github_client.hpp"
 #include "log.hpp"
+#include "tui.hpp"
 #include <iostream>
+#include <cstdlib>
 #include <spdlog/spdlog.h>
 
 namespace agpm {
@@ -23,6 +26,20 @@ int App::run(int argc, char **argv) {
     std::cout << "Verbose mode enabled" << std::endl;
   }
   std::cout << "Running agpm app" << std::endl;
+
+  if (argc == 1) {
+    const char *token = std::getenv("GITHUB_TOKEN");
+    const char *owner = std::getenv("GITHUB_OWNER");
+    const char *repo = std::getenv("GITHUB_REPO");
+    if (token && owner && repo) {
+      GitHubClient client(token);
+      auto prs = client.list_pull_requests(owner, repo);
+      Tui ui;
+      ui.run(prs);
+    } else {
+      spdlog::warn("TUI skipped: GITHUB_TOKEN/OWNER/REPO not set");
+    }
+  }
   return 0;
 }
 

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -1,0 +1,42 @@
+#include "tui.hpp"
+#include <curses.h>
+
+namespace agpm {
+
+Tui::Tui() { initscr(); cbreak(); noecho(); keypad(stdscr, TRUE); start_color(); use_default_colors(); init_pair(1, COLOR_CYAN, -1); }
+
+Tui::~Tui() { endwin(); }
+
+int Tui::run(const std::vector<PullRequest> &prs) {
+  if (prs.empty()) {
+    return 0;
+  }
+  int highlight = 0;
+  int offset = 0;
+  int ch = 0;
+  int rows, cols;
+  getmaxyx(stdscr, rows, cols);
+  while ((ch = getch()) != 'q') {
+    if (ch == KEY_DOWN && highlight < static_cast<int>(prs.size()) - 1)
+      ++highlight;
+    else if (ch == KEY_UP && highlight > 0)
+      --highlight;
+    if (highlight < offset)
+      offset = highlight;
+    else if (highlight >= offset + rows)
+      offset = highlight - rows + 1;
+    clear();
+    for (int i = 0; i < rows && i + offset < static_cast<int>(prs.size()); ++i) {
+      int idx = i + offset;
+      if (idx == highlight)
+        attron(COLOR_PAIR(1) | A_BOLD);
+      mvprintw(i, 0, "#%d %s", prs[idx].number, prs[idx].title.c_str());
+      if (idx == highlight)
+        attroff(COLOR_PAIR(1) | A_BOLD);
+    }
+    refresh();
+  }
+  return 0;
+}
+
+} // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,3 +25,7 @@ add_test(NAME github_client_behavior_test COMMAND test_github_client_behavior)
 add_executable(test_history test_history.cpp)
 target_link_libraries(test_history PRIVATE autogithubpullmerge_lib)
 add_test(NAME history_test COMMAND test_history)
+
+add_executable(test_tui test_tui.cpp)
+target_link_libraries(test_tui PRIVATE autogithubpullmerge_lib)
+add_test(NAME tui_test COMMAND test_tui)

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -1,0 +1,12 @@
+#include "tui.hpp"
+#include <cassert>
+#include <cstdlib>
+#include <vector>
+
+int main() {
+  setenv("TERM", "xterm", 1);
+  agpm::Tui ui;
+  std::vector<agpm::PullRequest> prs; // empty to exit immediately
+  assert(ui.run(prs) == 0);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- introduce a new ncurses-based TUI module
- link ncurses in build
- hook the UI when running without arguments
- add unit test for TUI

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688afc237f9883259fe90fadb913fd5c