### PR TITLE
Add g++ compile scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cmake-build-*/
 # OS-specific files
 .DS_Store
 Thumbs.db
+build_gpp/

--- a/README.md
+++ b/README.md
@@ -9,11 +9,23 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - Unit tests using Catch2
 - SQLite-based history storage with CSV/JSON export
 - Configurable logging with `--log-level`
+- Cross-platform compile scripts using g++
 
 ## Building (Linux)
 ```bash
 ./scripts/install_linux.sh
 ./scripts/build_linux.sh
+```
+
+## Compiling with g++
+
+On systems with g++ available, you can build the project without CMake using the
+provided scripts:
+
+```bash
+./scripts/compile_linux.sh   # Linux
+./scripts/compile_mac.sh     # macOS
+./scripts/compile_win.ps1    # Windows
 ```
 
 ## Generating Documentation

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${ROOT_DIR}/build_gpp"
+mkdir -p "$BUILD_DIR"
+SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
+
+g++ -std=c++20 -Wall -Wextra -O2 -I"${ROOT_DIR}/include" $SRC_FILES \
+  $(pkg-config --cflags --libs yaml-cpp libcurl sqlite3 spdlog ncurses) -pthread \
+  -o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="${SCRIPT_DIR}/.."
+BUILD_DIR="${ROOT_DIR}/build_gpp"
+mkdir -p "$BUILD_DIR"
+SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
+
+CPU_CORES=$(sysctl -n hw.ncpu)
+
+g++ -std=c++20 -Wall -Wextra -O2 -I"${ROOT_DIR}/include" $SRC_FILES \
+  $(pkg-config --cflags --libs yaml-cpp libcurl sqlite3 spdlog ncurses) -pthread \
+  -o "$BUILD_DIR/autogithubpullmerge"
+

--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -1,0 +1,11 @@
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$RootDir = Join-Path $ScriptDir ".."
+$BuildDir = Join-Path $RootDir "build_gpp"
+New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
+
+$srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
+$include = Join-Path $RootDir "include"
+$srcList = $srcFiles -join ' '
+
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -I`"$include`" $srcList -lcurl -lsqlite3 -lyaml-cpp -lspdlog -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
+Invoke-Expression $cmd


### PR DESCRIPTION
## Summary
- add cross-platform compile scripts using g++
- document new compile scripts in README
- ignore build_gpp output directory

## Testing
- `scripts/build_linux.sh`
- `bash scripts/compile_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b022faba48325b3501b61d81ce6c8