### PR TITLE
Fix mac build by removing CLI11 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 ./scripts/build_linux.sh
 ```
 
+## Building (macOS)
+```bash
+./scripts/install_mac.sh
+./scripts/build_mac.sh
+```
+
+If Homebrew is installed in a custom location, set the `PKG_CONFIG` environment
+variable to the full path of `pkg-config` before running the build scripts:
+
+```bash
+export PKG_CONFIG=$(which pkg-config)
+```
+
 ## Compiling with g++
 
 On systems with g++ available, you can build the project without CMake using the

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -3,6 +3,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 BUILD_DIR="${ROOT_DIR}/build_gpp"
+export PKG_CONFIG="$(which pkg-config)"
 mkdir -p "$BUILD_DIR"
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,3 @@
-find_package(CLI11 CONFIG REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CURL REQUIRED)
@@ -11,7 +10,7 @@ add_library(autogithubpullmerge_lib app.cpp cli.cpp config.cpp config_manager.cp
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CURSES_INCLUDE_DIR})
 
-target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp
+target_link_libraries(autogithubpullmerge_lib PUBLIC yaml-cpp
                                               nlohmann_json::nlohmann_json
                                               CURL::libcurl SQLite::SQLite3
                                               spdlog::spdlog ${CURSES_LIBRARIES})

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,31 +1,24 @@
+
 #include "cli.hpp"
-#include <CLI/CLI.hpp>
+#include <string>
 
 namespace agpm {
 
 CliOptions parse_cli(int argc, char **argv) {
-  CLI::App app{"autogithubpullmerge command line"};
   CliOptions options;
-  app.add_flag("-v,--verbose", options.verbose, "Enable verbose output");
-  app.add_option("--config", options.config_file, "Path to configuration file")
-      ->type_name("FILE");
-  app.add_option(
-         "--log-level", options.log_level,
-         "Set logging level (trace, debug, info, warn, error, critical, off)")
-      ->type_name("LEVEL")
-      ->default_val("info");
-  app.add_option("--include", options.include_repos,
-                 "Repository to include; repeatable")
-      ->type_name("REPO")
-      ->expected(-1);
-  app.add_option("--exclude", options.exclude_repos,
-                 "Repository to exclude; repeatable")
-      ->type_name("REPO")
-      ->expected(-1);
-  try {
-    app.parse(argc, argv);
-  } catch (const CLI::ParseError &e) {
-    exit(app.exit(e));
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "-v" || arg == "--verbose") {
+      options.verbose = true;
+    } else if (arg == "--config" && i + 1 < argc) {
+      options.config_file = argv[++i];
+    } else if (arg == "--log-level" && i + 1 < argc) {
+      options.log_level = argv[++i];
+    } else if (arg == "--include" && i + 1 < argc) {
+      options.include_repos.push_back(argv[++i]);
+    } else if (arg == "--exclude" && i + 1 < argc) {
+      options.exclude_repos.push_back(argv[++i]);
+    }
   }
   return options;
 }


### PR DESCRIPTION
## Summary
- implement minimal command-line parser to drop CLI11 requirement
- cleanup CMake links to remove CLI11
- ensure mac compilation uses pkg-config path
- document macOS build instructions

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b2730393083258b96c85b82b7d98e