### PR TITLE
Update build instructions for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 ./scripts/build_linux.sh
 ```
 
+## Building (macOS)
+```bash
+./scripts/install_mac.sh
+./scripts/update_libs.sh
+./scripts/build_mac.sh
+```
+
+## Building (Windows)
+```powershell
+./scripts/install_win.ps1
+./scripts/update_libs.ps1
+./scripts/build_win.ps1
+```
+
 ## Compiling with g++
 
 On systems with g++ available, you can build the project without CMake using the
@@ -31,8 +45,11 @@ provided scripts:
 ./scripts/compile_mac.sh     # macOS
 ./scripts/compile_win.ps1    # Windows
 ```
-Run `./scripts/update_libs.sh` (or `./scripts/update_libs.ps1` on Windows) beforehand to fetch the required libraries into
-the `libs` directory.
+Run the matching `install_*` script for your platform first to install system
+packages like **libcurl** and **sqlite3**. Then use `update_libs.sh` (or
+`update_libs.ps1` on Windows) to populate the `libs` directory with clones of
+**CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, **spdlog**, **curl** and
+**sqlite** before compiling.
 
 ## Generating Documentation
 

--- a/libs/README.md
+++ b/libs/README.md
@@ -1,4 +1,5 @@
 This directory holds third-party dependencies used by autogithubpullmerge.
-Run `./scripts/update_libs.sh` or `./scripts/update_libs.ps1` to clone or update them from their upstream
-repositories. The contents of this folder are ignored by git so clones are
-not committed to the repository.
+Run `./scripts/update_libs.sh` or `./scripts/update_libs.ps1` to clone or update
+third-party projects such as **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**,
+**spdlog**, **curl** and **sqlite**. The contents of this folder are ignored by
+git so clones are not committed to the repository.

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -6,8 +6,8 @@ BUILD_DIR="${ROOT_DIR}/build_gpp"
 mkdir -p "$BUILD_DIR"
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
-INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\""
+INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\" -I\"${LIBS_DIR}/libyaml/include\""
 
 g++ -std=c++20 -Wall -Wextra -O2 $INCLUDE_FLAGS $SRC_FILES \
-  $(pkg-config --cflags --libs yaml-cpp libcurl sqlite3 ncurses) -pthread \
-  -o "$BUILD_DIR/autogithubpullmerge"
+	$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses) -pthread \
+	-o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -6,11 +6,10 @@ BUILD_DIR="${ROOT_DIR}/build_gpp"
 mkdir -p "$BUILD_DIR"
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
-INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\""
+INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\" -I\"${LIBS_DIR}/libyaml/include\""
 
 CPU_CORES=$(sysctl -n hw.ncpu)
 
 g++ -std=c++20 -Wall -Wextra -O2 $INCLUDE_FLAGS $SRC_FILES \
-  $(pkg-config --cflags --libs yaml-cpp libcurl sqlite3 ncurses) -pthread \
-  -o "$BUILD_DIR/autogithubpullmerge"
-
+	$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses) -pthread \
+	-o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -7,7 +7,7 @@ $srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurs
 $include = Join-Path $RootDir "include"
 $libsDir = Join-Path $RootDir "libs"
 $srcList = $srcFiles -join ' '
-$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`""
+$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`""
 
-$cmd = "g++ -std=c++20 -Wall -Wextra -O2 $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
 Invoke-Expression $cmd

--- a/scripts/update_libs.ps1
+++ b/scripts/update_libs.ps1
@@ -13,5 +13,8 @@ function CloneOrUpdate($repo, $dir) {
 
 CloneOrUpdate "https://github.com/CLIUtils/CLI11.git" "CLI11"
 CloneOrUpdate "https://github.com/jbeder/yaml-cpp.git" "yaml-cpp"
+CloneOrUpdate "https://github.com/yaml/libyaml.git" "libyaml"
 CloneOrUpdate "https://github.com/nlohmann/json.git" "json"
 CloneOrUpdate "https://github.com/gabime/spdlog.git" "spdlog"
+CloneOrUpdate "https://github.com/curl/curl.git" "curl"
+CloneOrUpdate "https://github.com/sqlite/sqlite.git" "sqlite"

--- a/scripts/update_libs.sh
+++ b/scripts/update_libs.sh
@@ -5,17 +5,19 @@ LIBS_DIR="${SCRIPT_DIR}/../libs"
 mkdir -p "$LIBS_DIR"
 
 clone_or_update() {
-  local repo="$1"
-  local dir="$LIBS_DIR/$2"
-  if [ -d "$dir/.git" ]; then
-    git -C "$dir" pull --ff-only
-  else
-    git clone --depth 1 "$repo" "$dir"
-  fi
+	local repo="$1"
+	local dir="$LIBS_DIR/$2"
+	if [ -d "$dir/.git" ]; then
+		git -C "$dir" pull --ff-only
+	else
+		git clone --depth 1 "$repo" "$dir"
+	fi
 }
 
 clone_or_update https://github.com/CLIUtils/CLI11.git CLI11
 clone_or_update https://github.com/jbeder/yaml-cpp.git yaml-cpp
+clone_or_update https://github.com/yaml/libyaml.git libyaml
 clone_or_update https://github.com/nlohmann/json.git json
 clone_or_update https://github.com/gabime/spdlog.git spdlog
-
+clone_or_update https://github.com/curl/curl.git curl
+clone_or_update https://github.com/sqlite/sqlite.git sqlite


### PR DESCRIPTION
## Summary
- document install scripts for Windows and macOS
- clarify when to run install and update scripts before compiling
- clone missing libs (curl, sqlite, libyaml)
- update compile scripts to include libyaml

## Testing
- `./scripts/update_libs.sh`
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688b4d7112488325b0dc289ceceb955a