### PR TITLE
build: auto-fetch libs for win compile

### DIFF
--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -6,6 +6,11 @@ New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
 $srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
 $include = Join-Path $RootDir "include"
 $libsDir = Join-Path $RootDir "libs"
+$jsonLib = Join-Path $libsDir "json"
+if (-not (Test-Path $jsonLib)) {
+    Write-Host "Third-party libraries not found. Fetching with update_libs.ps1 ..."
+    & (Join-Path $ScriptDir "update_libs.ps1")
+}
 $srcList = $srcFiles -join ' '
 $includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\ncurses\include`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
 


### PR DESCRIPTION
## Summary
- improve `compile_win.ps1` to fetch third-party dependencies if missing

## Testing
- `cmake ..` *(fails: Could not find package configuration file provided by "CLI11" since deps aren't installed)*

------
https://chatgpt.com/codex/tasks/task_e_688b7bba7ee0832584db256f82b6d6e9