### PR TITLE
Fix SQLite VERSION clash

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -1,5 +1,7 @@
 This directory holds third-party dependencies used by autogithubpullmerge.
 Run `./scripts/update_libs.sh` or `./scripts/update_libs.ps1` to clone or update
-third-party projects such as **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**,
-**spdlog**, **curl**, **sqlite** and **ncurses**. The contents of this folder are ignored by
+third-party projects such as **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, 
+**spdlog**, **curl**, **sqlite** and **ncurses**. After cloning, the SQLite
+repository's `VERSION` file is renamed to `VERSION.txt` to prevent conflicts
+with the C++ `<version>` header. The contents of this folder are ignored by
 git so clones are not committed to the repository.

--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -7,7 +7,7 @@ $srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurs
 $include = Join-Path $RootDir "include"
 $libsDir = Join-Path $RootDir "libs"
 $srcList = $srcFiles -join ' '
-$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\ncurses\include`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
+$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\ncurses\include`" -I`"$libsDir\curl\include`""
 
 $cmd = "g++ -std=c++20 -Wall -Wextra -O2 -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
 Invoke-Expression $cmd

--- a/scripts/update_libs.ps1
+++ b/scripts/update_libs.ps1
@@ -18,4 +18,7 @@ CloneOrUpdate "https://github.com/nlohmann/json.git" "json"
 CloneOrUpdate "https://github.com/gabime/spdlog.git" "spdlog"
 CloneOrUpdate "https://github.com/curl/curl.git" "curl"
 CloneOrUpdate "https://github.com/sqlite/sqlite.git" "sqlite"
+if (Test-Path (Join-Path $LibsDir "sqlite\VERSION")) {
+    Rename-Item (Join-Path $LibsDir "sqlite\VERSION") "VERSION.txt"
+}
 CloneOrUpdate "https://github.com/mirror/ncurses.git" "ncurses"

--- a/scripts/update_libs.sh
+++ b/scripts/update_libs.sh
@@ -21,4 +21,6 @@ clone_or_update https://github.com/nlohmann/json.git json
 clone_or_update https://github.com/gabime/spdlog.git spdlog
 clone_or_update https://github.com/curl/curl.git curl
 clone_or_update https://github.com/sqlite/sqlite.git sqlite
+# Rename VERSION file to avoid clashing with C++ <version> header
+[ -f "$LIBS_DIR/sqlite/VERSION" ] && mv "$LIBS_DIR/sqlite/VERSION" "$LIBS_DIR/sqlite/VERSION.txt"
 clone_or_update https://github.com/mirror/ncurses.git ncurses


### PR DESCRIPTION
## Summary
- avoid C++ `<version>` header collision from SQLite
- rename SQLite `VERSION` file when fetching libs
- remove SQLite include dir from Windows compile script
- document the rename in libs README

## Testing
- `./scripts/install_linux.sh`
- `./scripts/update_libs.sh`
- `./scripts/build_linux.sh`


------
https://chatgpt.com/codex/tasks/task_e_688b9e6e65d0832599d4409cd9f80f45