### PR TITLE
Fix includes for sqlite and curses

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -2,6 +2,7 @@
 #define AUTOGITHUBPULLMERGE_TUI_HPP
 
 #include "github_client.hpp"
+#include <curses.h>
 #include <vector>
 
 namespace agpm {

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,5 +1,6 @@
 #include "history.hpp"
 #include <fstream>
+#include <sqlite3.h>
 #include <stdexcept>
 
 namespace agpm {


### PR DESCRIPTION
## Summary
- add missing `<curses.h>` include in `Tui` header
- include `<sqlite3.h>` in `history.cpp`

## Testing
- `./scripts/update_libs.sh`
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ba1713fc883258d3249de5d907776