### PR TITLE
Fix Windows g++ compile script and build flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ provided scripts:
 Run the matching `install_*` script for your platform first to install system
 packages like **libcurl** and **sqlite3**. Then use `update_libs.sh` (or
 `update_libs.ps1` on Windows) to populate the `libs` directory with clones of
-**CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, **spdlog**, **curl** and
-**sqlite** before compiling.
+**CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, **spdlog**, **curl**,
+**sqlite** and **ncurses/pdcurses** before compiling. The Windows compile
+script links the application statically so the resulting binary has no runtime
+library dependencies.
 
 ## Generating Documentation
 

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -3,6 +3,6 @@ set -e
 BUILD_DIR="build"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-cmake ..
+cmake .. -DBUILD_SHARED_LIBS=OFF
 cmake --build . -- -j$(nproc)
 ctest

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -3,6 +3,6 @@ set -e
 BUILD_DIR="build"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
-cmake ..
+cmake .. -DBUILD_SHARED_LIBS=OFF
 cmake --build . -- -j$(sysctl -n hw.ncpu)
 ctest

--- a/scripts/build_win.ps1
+++ b/scripts/build_win.ps1
@@ -1,5 +1,5 @@
 mkdir -Force build
 cd build
-cmake .. -G "NMake Makefiles"
+cmake .. -G "NMake Makefiles" -DBUILD_SHARED_LIBS=OFF
 cmake --build . -- /M
 ctest

--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -7,7 +7,6 @@ $srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurs
 $include = Join-Path $RootDir "include"
 $libsDir = Join-Path $RootDir "libs"
 $srcList = $srcFiles -join ' '
-$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\ncurses\include`" -I`"$libsDir\curl\include`""
-
-$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
+$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\ncurses\include`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
 Invoke-Expression $cmd


### PR DESCRIPTION
## Summary
- statically link compile_win.ps1 and add sqlite include
- enforce static libraries in build scripts
- document Windows static build requirements

## Testing
- `scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ba3e3b6d88325aae18a82826de73b