### PR TITLE
Fix mac compile script

### DIFF
--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -1,15 +1,35 @@
 #!/usr/bin/env bash
 set -e
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 BUILD_DIR="${ROOT_DIR}/build_gpp"
 mkdir -p "$BUILD_DIR"
+
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
-INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\" -I\"${LIBS_DIR}/libyaml/include\" -I\"${LIBS_DIR}/ncurses/include\" -I\"${LIBS_DIR}/curl/include\""
+
+# Include directories for project headers and third-party libraries
+INCLUDE_FLAGS=(
+    "-I${ROOT_DIR}/include"
+    "-I${LIBS_DIR}/CLI11/include"
+    "-I${LIBS_DIR}/json/include"
+    "-I${LIBS_DIR}/spdlog/include"
+    "-I${LIBS_DIR}/yaml-cpp/include"
+    "-I${LIBS_DIR}/libyaml/include"
+    "-I${LIBS_DIR}/ncurses/include"
+    "-I${LIBS_DIR}/curl/include"
+)
+
+if command -v pkg-config >/dev/null; then
+    PKG_FLAGS=$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses)
+else
+    echo "pkg-config not found, using fallback flags"
+    PKG_FLAGS="-lyaml-cpp -lyaml -lcurl -lsqlite3 -lncurses"
+fi
 
 CPU_CORES=$(sysctl -n hw.ncpu)
 
-g++ -std=c++20 -Wall -Wextra -O2 $INCLUDE_FLAGS $SRC_FILES \
-	$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses) -pthread \
-	-o "$BUILD_DIR/autogithubpullmerge"
+# shellcheck disable=SC2068
+g++ -std=c++20 -Wall -Wextra -O2 ${INCLUDE_FLAGS[@]} $SRC_FILES $PKG_FLAGS -pthread \
+    -o "$BUILD_DIR/autogithubpullmerge"


### PR DESCRIPTION
## Summary
- improve `compile_mac.sh`
  - add fallback when `pkg-config` is missing
  - ensure project and third-party include directories are passed correctly

## Testing
- `./scripts/update_libs.sh`
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bb17dbeec83259a73980467913e40