### PR TITLE
Add additional tests for CLI, config and GitHub client

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,3 +38,15 @@ add_test(NAME github_filter_test COMMAND test_github_filter)
 add_executable(test_poller test_poller.cpp)
 target_link_libraries(test_poller PRIVATE autogithubpullmerge_lib)
 add_test(NAME poller_test COMMAND test_poller)
+
+add_executable(test_cli_tokens test_cli_tokens.cpp)
+target_link_libraries(test_cli_tokens PRIVATE autogithubpullmerge_lib)
+add_test(NAME cli_tokens_test COMMAND test_cli_tokens)
+
+add_executable(test_config_loading test_config_loading.cpp)
+target_link_libraries(test_config_loading PRIVATE autogithubpullmerge_lib)
+add_test(NAME config_loading_test COMMAND test_config_loading)
+
+add_executable(test_github_client_headers test_github_client_headers.cpp)
+target_link_libraries(test_github_client_headers PRIVATE autogithubpullmerge_lib)
+add_test(NAME github_client_headers_test COMMAND test_github_client_headers)

--- a/tests/test_cli_tokens.cpp
+++ b/tests/test_cli_tokens.cpp
@@ -1,0 +1,32 @@
+#include "cli.hpp"
+#include <cassert>
+#include <fstream>
+
+int main() {
+  // Load tokens from YAML file
+  {
+    std::ofstream f("tokens.yaml");
+    f << "tokens:\n  - a\n  - b\n";
+    f.close();
+  }
+  char prog[] = "prog";
+  char flag[] = "--api-key-file";
+  char file[] = "tokens.yaml";
+  char *argv1[] = {prog, flag, file};
+  agpm::CliOptions opts = agpm::parse_cli(3, argv1);
+  assert(opts.api_keys.size() == 2);
+  assert(opts.api_keys[0] == "a");
+  assert(opts.api_keys[1] == "b");
+
+  // Multiple --api-key options
+  char api_flag[] = "--api-key";
+  char k1[] = "c";
+  char k2[] = "d";
+  char *argv2[] = {prog, api_flag, k1, api_flag, k2};
+  agpm::CliOptions opts2 = agpm::parse_cli(5, argv2);
+  assert(opts2.api_keys.size() == 2);
+  assert(opts2.api_keys[0] == "c");
+  assert(opts2.api_keys[1] == "d");
+
+  return 0;
+}

--- a/tests/test_config_loading.cpp
+++ b/tests/test_config_loading.cpp
@@ -1,0 +1,27 @@
+#include "config.hpp"
+#include <cassert>
+#include <fstream>
+
+int main() {
+  {
+    std::ofstream f("config.yaml");
+    f << "verbose: true\npoll_interval: 10\nmax_request_rate: 20\n";
+    f.close();
+  }
+  agpm::Config ycfg = agpm::Config::from_file("config.yaml");
+  assert(ycfg.verbose());
+  assert(ycfg.poll_interval() == 10);
+  assert(ycfg.max_request_rate() == 20);
+
+  {
+    std::ofstream f("config.json");
+    f << "{\"verbose\":false,\"poll_interval\":5,\"max_request_rate\":15}";
+    f.close();
+  }
+  agpm::Config jcfg = agpm::Config::from_file("config.json");
+  assert(!jcfg.verbose());
+  assert(jcfg.poll_interval() == 5);
+  assert(jcfg.max_request_rate() == 15);
+
+  return 0;
+}

--- a/tests/test_github_client_headers.cpp
+++ b/tests/test_github_client_headers.cpp
@@ -1,0 +1,54 @@
+#include "github_client.hpp"
+#include <cassert>
+#include <string>
+#include <vector>
+
+using namespace agpm;
+
+class HeaderHttpClient : public HttpClient {
+public:
+  std::vector<std::string> last_headers;
+  std::string response;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    last_headers = headers;
+    return response;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    last_headers = headers;
+    return response;
+  }
+};
+
+int main() {
+  auto http = std::make_unique<HeaderHttpClient>();
+  http->response = "[]";
+  HeaderHttpClient *raw = http.get();
+  GitHubClient client("token123", std::unique_ptr<HttpClient>(http.release()));
+  client.list_pull_requests("owner", "repo");
+  bool found = false;
+  for (const auto &h : raw->last_headers) {
+    if (h == "Authorization: token token123")
+      found = true;
+  }
+  assert(found);
+
+  auto http2 = std::make_unique<HeaderHttpClient>();
+  http2->response = "{\"merged\":true}";
+  HeaderHttpClient *raw2 = http2.get();
+  GitHubClient client2("tok", std::unique_ptr<HttpClient>(http2.release()));
+  bool merged = client2.merge_pull_request("owner", "repo", 1);
+  assert(merged);
+  found = false;
+  for (const auto &h : raw2->last_headers) {
+    if (h == "Authorization: token tok")
+      found = true;
+  }
+  assert(found);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add tests covering CLI token parsing
- add tests for config loading from YAML and JSON
- verify GitHub client sends authorization headers
- register new tests in the build

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688bca4ce7d4832597b55a8969c69885