### PR TITLE
Fix includes for sqlite3 and curses

### DIFF
--- a/include/history.hpp
+++ b/include/history.hpp
@@ -2,7 +2,14 @@
 #define AUTOGITHUBPULLMERGE_HISTORY_HPP
 
 #include <nlohmann/json.hpp>
+
+#if __has_include(<sqlite3.h>)
 #include <sqlite3.h>
+#elif __has_include("../libs/sqlite/sqlite3.h")
+#include "../libs/sqlite/sqlite3.h"
+#else
+#error "sqlite3.h not found"
+#endif
 #include <string>
 
 namespace agpm {

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -1,7 +1,17 @@
 #ifndef AUTOGITHUBPULLMERGE_TUI_HPP
 #define AUTOGITHUBPULLMERGE_TUI_HPP
 
+#if __has_include(<curses.h>)
 #include <curses.h>
+#elif __has_include(<ncurses.h>)
+#include <ncurses.h>
+#elif __has_include(<ncurses/curses.h>)
+#include <ncurses/curses.h>
+#elif __has_include("../libs/ncurses/include/curses.h")
+#include "../libs/ncurses/include/curses.h"
+#else
+#error "curses.h not found"
+#endif
 
 namespace agpm {
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,6 +1,14 @@
 #include "history.hpp"
 #include <fstream>
+
+#if __has_include(<sqlite3.h>)
 #include <sqlite3.h>
+#elif __has_include("../libs/sqlite/sqlite3.h")
+#include "../libs/sqlite/sqlite3.h"
+#else
+#error "sqlite3.h not found"
+#endif
+
 #include <stdexcept>
 
 namespace agpm {

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -1,5 +1,16 @@
 #include "tui.hpp"
+
+#if __has_include(<curses.h>)
 #include <curses.h>
+#elif __has_include(<ncurses.h>)
+#include <ncurses.h>
+#elif __has_include(<ncurses/curses.h>)
+#include <ncurses/curses.h>
+#elif __has_include("../libs/ncurses/include/curses.h")
+#include "../libs/ncurses/include/curses.h"
+#else
+#error "curses.h not found"
+#endif
 
 namespace agpm {
 


### PR DESCRIPTION
## Summary
- fallback to bundled dependencies for sqlite3 and curses

## Testing
- `scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bd55bbf788325bdea9875d38764a8