### PR TITLE
Add PR merge history tracking

### DIFF
--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -19,6 +19,7 @@ struct CliOptions {
   std::string api_key_url_user;           ///< Basic auth user
   std::string api_key_url_password;       ///< Basic auth password
   std::string api_key_file;               ///< File containing tokens
+  std::string history_db = "history.db"; ///< SQLite history database path
   int poll_interval = 0;                  ///< Polling interval in seconds
   int max_request_rate = 60;              ///< Max requests per minute
 };

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -2,6 +2,7 @@
 #include "cli.hpp"
 #include "config.hpp"
 #include "log.hpp"
+#include "history.hpp"
 #include <cstdlib>
 #include <iostream>
 #include <spdlog/spdlog.h>
@@ -20,6 +21,8 @@ int App::run(int argc, char **argv) {
   if (!options_.config_file.empty()) {
     config_ = Config::from_file(options_.config_file);
   }
+  PullRequestHistory history(options_.history_db);
+  (void)history;
   if (options_.verbose) {
     std::cout << "Verbose mode enabled" << std::endl;
   }

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -134,6 +134,10 @@ CliOptions parse_cli(int argc, char **argv) {
   app.add_option("--api-key-file", options.api_key_file,
                  "Path to JSON/YAML file with API key(s)")
       ->type_name("FILE");
+  app.add_option("--history-db", options.history_db,
+                 "Path to SQLite history database")
+      ->type_name("FILE")
+      ->default_val("history.db");
   app.add_option("--poll-interval", options.poll_interval,
                  "Polling interval in seconds")
       ->type_name("SECONDS")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,3 +53,7 @@ add_test(NAME github_client_headers_test COMMAND test_github_client_headers)
 add_executable(test_github_client_delay test_github_client_delay.cpp)
 target_link_libraries(test_github_client_delay PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_client_delay_test COMMAND test_github_client_delay)
+
+add_executable(test_history_merge test_history_merge.cpp)
+target_link_libraries(test_history_merge PRIVATE autogithubpullmerge_lib)
+add_test(NAME history_merge_test COMMAND test_history_merge)

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -81,5 +81,11 @@ int main() {
   assert(opts11.poll_interval == 5);
   assert(opts11.max_request_rate == 100);
 
+  char db_flag[] = "--history-db";
+  char path_db[] = "my.db";
+  char *argv12[] = {prog, db_flag, path_db};
+  agpm::CliOptions opts12 = agpm::parse_cli(3, argv12);
+  assert(opts12.history_db == "my.db");
+
   return 0;
 }

--- a/tests/test_history_merge.cpp
+++ b/tests/test_history_merge.cpp
@@ -1,0 +1,51 @@
+#include "github_client.hpp"
+#include "history.hpp"
+#include <cassert>
+#include <fstream>
+
+using namespace agpm;
+
+class DummyHttp : public HttpClient {
+public:
+  std::string resp_get;
+  std::string resp_put;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return resp_get;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return resp_put;
+  }
+};
+
+int main() {
+  auto http = std::make_unique<DummyHttp>();
+  http->resp_get = "[{\"number\":1,\"title\":\"One\"},{\"number\":2,\"title\":\"Two\"}]";
+  http->resp_put = "{\"merged\":true}";
+  DummyHttp *raw = http.get();
+  (void)raw;
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  auto prs = client.list_pull_requests("me", "repo");
+  PullRequestHistory hist("merge_test.db");
+  for (const auto &pr : prs) {
+    bool merged = client.merge_pull_request("me", "repo", pr.number);
+    hist.insert(pr.number, pr.title, merged);
+  }
+  hist.export_json("merge.json");
+  std::ifstream f("merge.json");
+  nlohmann::json j;
+  f >> j;
+  assert(j.size() == 2);
+  assert(j[0]["number"] == 1);
+  assert(j[0]["title"] == "One");
+  assert(j[0]["merged"] == true);
+  std::remove("merge_test.db");
+  std::remove("merge.json");
+  return 0;
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -40,6 +40,17 @@ int main() {
   assert(log_app.run(static_cast<int>(args_log.size()), args_log.data()) == 0);
   assert(log_app.options().log_level == "warn");
 
+  agpm::App hist_app;
+  std::vector<char *> hist_args;
+  char prog4[] = "tests";
+  char db_flag[] = "--history-db";
+  char hist_file[] = "hist.db";
+  hist_args.push_back(prog4);
+  hist_args.push_back(db_flag);
+  hist_args.push_back(hist_file);
+  assert(hist_app.run(static_cast<int>(hist_args.size()), hist_args.data()) == 0);
+  assert(hist_app.options().history_db == "hist.db");
+
   {
     std::ofstream yaml("test_config.yaml");
     yaml << "verbose: true\n";


### PR DESCRIPTION
## Summary
- support `--history-db` CLI option in `CliOptions`
- record merge history database path in `App`
- add tests for new option and merge history database

## Testing
- `cmake .. -DBUILD_SHARED_LIBS=OFF`
- `cmake --build . -- -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688bd89512708325bc631f40811c0767