### PR TITLE
Integrate spdlog logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,5 +14,12 @@ endif()
 
 enable_testing()
 
+set(LIBS_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libs)
+if(EXISTS "${LIBS_DIR}/spdlog/CMakeLists.txt")
+  add_subdirectory(${LIBS_DIR}/spdlog EXTERNAL_SPDLOG_ROOT)
+else()
+  find_package(spdlog REQUIRED)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# autogithubpullmerge
+#autogithubpullmerge
 
 A cross-platform tool to manage and monitor GitHub pull requests from a terminal user interface.
 
@@ -11,6 +11,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - Unit tests using Catch2
 - SQLite-based history storage with CSV/JSON export
 - Configurable logging with `--log-level`
+- Uses spdlog for colored console logging
 - Cross-platform compile scripts using g++
 - CLI options for GitHub API keys (`--api-key`, `--api-key-from-stream`,
   `--api-key-url`, `--api-key-url-user`, `--api-key-url-password`,
@@ -66,8 +67,11 @@ doxygen docs/Doxyfile
 
 ## Logging
 
-Use the `--log-level` option to control verbosity. Valid levels include
+Logging output uses the **spdlog** library with colorized messages by default.
+The `--log-level` option controls verbosity. Valid levels include
 `trace`, `debug`, `info`, `warn`, `error`, `critical` and `off`.
+Passing `--verbose` sets the logger to the `debug` level unless `--log-level`
+specifies another level.
 
 ## API Key Options
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,12 +18,6 @@ else()
   find_package(nlohmann_json REQUIRED)
 endif()
 
-if(EXISTS "${LIBS_DIR}/spdlog/CMakeLists.txt")
-  add_subdirectory(${LIBS_DIR}/spdlog EXTERNAL_SPDLOG)
-else()
-  find_package(spdlog REQUIRED)
-endif()
-
 if(EXISTS "${LIBS_DIR}/curl/CMakeLists.txt")
   add_subdirectory(${LIBS_DIR}/curl EXTERNAL_CURL)
 else()

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,17 +1,17 @@
 #include "app.hpp"
 #include "cli.hpp"
 #include "config.hpp"
-#include "log.hpp"
 #include "history.hpp"
+#include "log.hpp"
 #include <cstdlib>
-#include <iostream>
 #include <spdlog/spdlog.h>
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
-  spdlog::level::level_enum lvl = spdlog::level::info;
+  spdlog::level::level_enum lvl =
+      options_.verbose ? spdlog::level::debug : spdlog::level::info;
   try {
     lvl = spdlog::level::from_str(options_.log_level);
   } catch (const spdlog::spdlog_ex &) {
@@ -24,9 +24,9 @@ int App::run(int argc, char **argv) {
   PullRequestHistory history(options_.history_db);
   (void)history;
   if (options_.verbose) {
-    std::cout << "Verbose mode enabled" << std::endl;
+    spdlog::debug("Verbose mode enabled");
   }
-  std::cout << "Running agpm app" << std::endl;
+  spdlog::info("Running agpm app");
 
   // Application logic goes here
   return 0;


### PR DESCRIPTION
## Summary
- add spdlog as dependency at the top level
- initialize the logger in `App::run`
- log messages through spdlog instead of `std::cout`
- document logging behaviour in README

## Testing
- `./scripts/install_linux.sh`
- `./scripts/update_libs.sh`
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688bde71fda08325ab2b3fc845a42456