### PR TITLE
Fix Windows build by fetching SQLite amalgamation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Run the matching `install_*` script for your platform first to install system
 packages like **libcurl**, **sqlite3** and **ncurses**. Then use `update_libs.sh` (or
 `update_libs.ps1` on Windows) to populate the `libs` directory with clones of
 **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, **spdlog**, **curl**,
-**sqlite** and **ncurses/pdcurses** before compiling. The Windows compile
+the SQLite amalgamation and **PDCurses** before compiling. The Windows compile
 script links the application statically so the resulting binary has no runtime
 library dependencies.
 

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -7,8 +7,8 @@
 #include <ncurses.h>
 #elif __has_include(<ncurses/curses.h>)
 #include <ncurses/curses.h>
-#elif __has_include("../libs/ncurses/include/curses.h")
-#include "../libs/ncurses/include/curses.h"
+#elif __has_include("../libs/pdcurses/curses.h")
+#include "../libs/pdcurses/curses.h"
 #else
 #error "curses.h not found"
 #endif

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -6,7 +6,7 @@ BUILD_DIR="${ROOT_DIR}/build_gpp"
 mkdir -p "$BUILD_DIR"
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
-INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\" -I\"${LIBS_DIR}/libyaml/include\" -I\"${LIBS_DIR}/ncurses/include\" -I\"${LIBS_DIR}/curl/include\""
+INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\" -I\"${LIBS_DIR}/libyaml/include\" -I\"${LIBS_DIR}/pdcurses\" -I\"${LIBS_DIR}/curl/include\""
 
 g++ -std=c++20 -Wall -Wextra -O2 $INCLUDE_FLAGS $SRC_FILES \
 	$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses) -pthread \

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -17,7 +17,7 @@ INCLUDE_FLAGS=(
     "-I${LIBS_DIR}/spdlog/include"
     "-I${LIBS_DIR}/yaml-cpp/include"
     "-I${LIBS_DIR}/libyaml/include"
-    "-I${LIBS_DIR}/ncurses/include"
+    "-I${LIBS_DIR}/pdcurses"
     "-I${LIBS_DIR}/curl/include"
 )
 

--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -6,11 +6,7 @@ New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
 $srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
 $include = Join-Path $RootDir "include"
 $libsDir = Join-Path $RootDir "libs"
-$sqliteVersion = Join-Path $libsDir "sqlite\VERSION"
-if (Test-Path $sqliteVersion) {
-    Rename-Item $sqliteVersion "VERSION.txt" -Force
-}
 $srcList = $srcFiles -join ' '
-$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\ncurses\include`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
-$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lncurses -o `"$BuildDir\autogithubpullmerge.exe`""
+$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\pdcurses`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lpdcurses -o `"$BuildDir\autogithubpullmerge.exe`""
 Invoke-Expression $cmd

--- a/scripts/update_libs.ps1
+++ b/scripts/update_libs.ps1
@@ -17,8 +17,20 @@ CloneOrUpdate "https://github.com/yaml/libyaml.git" "libyaml"
 CloneOrUpdate "https://github.com/nlohmann/json.git" "json"
 CloneOrUpdate "https://github.com/gabime/spdlog.git" "spdlog"
 CloneOrUpdate "https://github.com/curl/curl.git" "curl"
-CloneOrUpdate "https://github.com/sqlite/sqlite.git" "sqlite"
-if (Test-Path (Join-Path $LibsDir "sqlite\VERSION")) {
-    Rename-Item (Join-Path $LibsDir "sqlite\VERSION") "VERSION.txt"
+
+# Download SQLite amalgamation containing sqlite3.c and sqlite3.h
+$sqliteVer = "3430000"
+$sqliteYear = "2023"
+$sqliteZip = "sqlite-amalgamation-$sqliteVer.zip"
+$sqliteDir = Join-Path $LibsDir "sqlite"
+New-Item -ItemType Directory -Path $sqliteDir -Force | Out-Null
+if (-not (Test-Path (Join-Path $sqliteDir "sqlite3.h"))) {
+    $zipPath = Join-Path $sqliteDir $sqliteZip
+    Invoke-WebRequest -Uri "https://sqlite.org/$sqliteYear/$sqliteZip" -OutFile $zipPath
+    Expand-Archive -Path $zipPath -DestinationPath $sqliteDir -Force
+    Move-Item -Path (Join-Path $sqliteDir "sqlite-amalgamation-$sqliteVer\*") -Destination $sqliteDir
+    Remove-Item -Recurse -Force (Join-Path $sqliteDir "sqlite-amalgamation-$sqliteVer")
+    Remove-Item $zipPath
 }
-CloneOrUpdate "https://github.com/mirror/ncurses.git" "ncurses"
+
+CloneOrUpdate "https://github.com/wmcbrine/PDCurses.git" "pdcurses"

--- a/scripts/update_libs.sh
+++ b/scripts/update_libs.sh
@@ -20,7 +20,19 @@ clone_or_update https://github.com/yaml/libyaml.git libyaml
 clone_or_update https://github.com/nlohmann/json.git json
 clone_or_update https://github.com/gabime/spdlog.git spdlog
 clone_or_update https://github.com/curl/curl.git curl
-clone_or_update https://github.com/sqlite/sqlite.git sqlite
-# Rename VERSION file to avoid clashing with C++ <version> header
-[ -f "$LIBS_DIR/sqlite/VERSION" ] && mv "$LIBS_DIR/sqlite/VERSION" "$LIBS_DIR/sqlite/VERSION.txt"
-clone_or_update https://github.com/mirror/ncurses.git ncurses
+
+# Download SQLite amalgamation containing sqlite3.c and sqlite3.h
+SQLITE_VER=3430000
+SQLITE_YEAR=2023
+SQLITE_ZIP="sqlite-amalgamation-${SQLITE_VER}.zip"
+SQLITE_DIR="$LIBS_DIR/sqlite"
+mkdir -p "$SQLITE_DIR"
+if [ ! -f "$SQLITE_DIR/sqlite3.h" ]; then
+    curl -L "https://sqlite.org/${SQLITE_YEAR}/${SQLITE_ZIP}" -o "$SQLITE_DIR/${SQLITE_ZIP}"
+    unzip -oq "$SQLITE_DIR/${SQLITE_ZIP}" -d "$SQLITE_DIR"
+    mv "$SQLITE_DIR/sqlite-amalgamation-${SQLITE_VER}"/* "$SQLITE_DIR"
+    rmdir "$SQLITE_DIR/sqlite-amalgamation-${SQLITE_VER}"
+    rm "$SQLITE_DIR/${SQLITE_ZIP}"
+fi
+
+clone_or_update https://github.com/wmcbrine/PDCurses.git pdcurses

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -6,8 +6,8 @@
 #include <ncurses.h>
 #elif __has_include(<ncurses/curses.h>)
 #include <ncurses/curses.h>
-#elif __has_include("../libs/ncurses/include/curses.h")
-#include "../libs/ncurses/include/curses.h"
+#elif __has_include("../libs/pdcurses/curses.h")
+#include "../libs/pdcurses/curses.h"
 #else
 #error "curses.h not found"
 #endif


### PR DESCRIPTION
## Summary
- fetch sqlite3 amalgamation during update_libs scripts
- switch bundled curses library to PDCurses
- use PDCurses headers in the source
- adjust compile scripts for PDCurses
- document new dependency workflow

## Testing
- `bash scripts/update_libs.sh`
- `cmake -B build -S . -DBUILD_SHARED_LIBS=OFF`
- `cmake --build build -j $(nproc)`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688bdf8370ac8325b4ad902e06a9f0dc