### PR TITLE
Add GitHub polling worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ API keys can be provided in several ways:
 - `--poll-interval` sets how often the application polls GitHub for updates in
   seconds. A value of `0` disables polling.
 - `--max-request-rate` limits the maximum number of GitHub requests per minute
-  using a token bucket algorithm.
+  using a token bucket algorithm. When polling is enabled a background worker
+  thread periodically invokes the GitHub API.
 
 ## Examples
 

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -1,4 +1,4 @@
-# Usage Summary
+#Usage Summary
 
 This document highlights the main command line options, examples of
 configuration files, logging behaviour, available TUI features, and how
@@ -22,7 +22,8 @@ to build the project on supported platforms.
   from a remote URL with optional basic authentication.
 - `--api-key-file` - load tokens from a local YAML or JSON file.
 - `--poll-interval` - how often to poll GitHub (seconds, `0` disables).
-- `--max-request-rate` - limit GitHub requests per minute.
+- `--max-request-rate` - limit GitHub requests per minute. When polling is
+  enabled a worker thread fetches pull requests at the configured interval.
 
 ## Configuration File Examples
 

--- a/include/github_poller.hpp
+++ b/include/github_poller.hpp
@@ -1,0 +1,41 @@
+#ifndef AUTOGITHUBPULLMERGE_GITHUB_POLLER_HPP
+#define AUTOGITHUBPULLMERGE_GITHUB_POLLER_HPP
+
+#include "github_client.hpp"
+#include "poller.hpp"
+#include <utility>
+#include <vector>
+
+namespace agpm {
+
+/** Polls GitHub repositories periodically using a token bucket. */
+class GitHubPoller {
+public:
+  /**
+   * Construct a poller.
+   *
+   * @param client GitHub API client
+   * @param repos List of {owner, repo} pairs to poll
+   * @param interval_ms Poll interval in milliseconds
+   * @param max_rate Maximum requests per minute
+   */
+  GitHubPoller(GitHubClient &client,
+               std::vector<std::pair<std::string, std::string>> repos,
+               int interval_ms, int max_rate);
+
+  /// Start polling in a background thread.
+  void start();
+  /// Stop polling.
+  void stop();
+
+private:
+  void poll();
+
+  GitHubClient &client_;
+  std::vector<std::pair<std::string, std::string>> repos_;
+  Poller poller_;
+};
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_GITHUB_POLLER_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,8 @@ add_library(autogithubpullmerge_lib
             history.cpp
             log.cpp
             tui.cpp
-            poller.cpp)
+            poller.cpp
+            github_poller.cpp)
 
 target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CURSES_INCLUDE_DIR})
 

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -1,0 +1,22 @@
+#include "github_poller.hpp"
+
+namespace agpm {
+
+GitHubPoller::GitHubPoller(
+    GitHubClient &client,
+    std::vector<std::pair<std::string, std::string>> repos, int interval_ms,
+    int max_rate)
+    : client_(client), repos_(std::move(repos)),
+      poller_([this] { poll(); }, interval_ms, max_rate) {}
+
+void GitHubPoller::start() { poller_.start(); }
+
+void GitHubPoller::stop() { poller_.stop(); }
+
+void GitHubPoller::poll() {
+  for (const auto &r : repos_) {
+    client_.list_pull_requests(r.first, r.second);
+  }
+}
+
+} // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,3 +60,7 @@ add_test(NAME github_client_accept_test COMMAND test_github_client_accept)
 add_executable(test_history_merge test_history_merge.cpp)
 target_link_libraries(test_history_merge PRIVATE autogithubpullmerge_lib)
 add_test(NAME history_merge_test COMMAND test_history_merge)
+
+add_executable(test_github_poller test_github_poller.cpp)
+target_link_libraries(test_github_poller PRIVATE autogithubpullmerge_lib)
+add_test(NAME github_poller_test COMMAND test_github_poller)

--- a/tests/test_github_poller.cpp
+++ b/tests/test_github_poller.cpp
@@ -1,0 +1,50 @@
+#include "github_poller.hpp"
+#include <atomic>
+#include <cassert>
+#include <chrono>
+#include <thread>
+
+using namespace agpm;
+
+class CountHttpClient : public HttpClient {
+public:
+  explicit CountHttpClient(std::atomic<int> &c) : counter(c) {}
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    ++counter;
+    return "[]";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+
+private:
+  std::atomic<int> &counter;
+};
+
+int main() {
+  std::atomic<int> count1{0};
+  auto http1 = std::make_unique<CountHttpClient>(count1);
+  GitHubClient client1("tok", std::unique_ptr<HttpClient>(http1.release()));
+  GitHubPoller poller1(client1, {{"me", "repo"}}, 50, 120);
+  poller1.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(220));
+  poller1.stop();
+  assert(count1 >= 3); // should run ~4 times
+
+  std::atomic<int> count2{0};
+  auto http2 = std::make_unique<CountHttpClient>(count2);
+  GitHubClient client2("tok", std::unique_ptr<HttpClient>(http2.release()));
+  GitHubPoller poller2(client2, {{"me", "repo"}}, 50, 1);
+  poller2.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(220));
+  poller2.stop();
+  assert(count2 == 1); // rate limited to first token
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add `GitHubPoller` helper for periodic GitHub API calls
- document polling worker behaviour
- test the poller logic

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c9f58394083259cde15bf88cdaebe