### PR TITLE
Add include/exclude repo lists to App

### DIFF
--- a/include/app.hpp
+++ b/include/app.hpp
@@ -3,6 +3,7 @@
 
 #include "cli.hpp"
 #include "config.hpp"
+#include <vector>
 
 namespace agpm {
 
@@ -24,9 +25,21 @@ public:
   /** Retrieve the loaded configuration. */
   const Config &config() const { return config_; }
 
+  /// Repositories explicitly included via the CLI.
+  const std::vector<std::string> &include_repos() const {
+    return include_repos_;
+  }
+
+  /// Repositories explicitly excluded via the CLI.
+  const std::vector<std::string> &exclude_repos() const {
+    return exclude_repos_;
+  }
+
 private:
   CliOptions options_;
   Config config_;
+  std::vector<std::string> include_repos_;
+  std::vector<std::string> exclude_repos_;
 };
 
 } // namespace agpm

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -10,6 +10,8 @@ namespace agpm {
 
 int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
+  include_repos_ = options_.include_repos;
+  exclude_repos_ = options_.exclude_repos;
   spdlog::level::level_enum lvl =
       options_.verbose ? spdlog::level::debug : spdlog::level::info;
   try {

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -45,6 +45,14 @@ int main() {
   assert(opts7.exclude_repos.size() == 1);
   assert(opts7.exclude_repos[0] == "repoC");
 
+  char repo_d[] = "repoD";
+  char repo_e[] = "repoE";
+  char *argv7b[] = {prog, exclude_flag, repo_d, exclude_flag, repo_e};
+  agpm::CliOptions opts7b = agpm::parse_cli(5, argv7b);
+  assert(opts7b.exclude_repos.size() == 2);
+  assert(opts7b.exclude_repos[0] == "repoD");
+  assert(opts7b.exclude_repos[1] == "repoE");
+
   char api_flag[] = "--api-key";
   char key1[] = "abc";
   char key2[] = "def";


### PR DESCRIPTION
## Summary
- expose repeatable `--include` and `--exclude` lists in the App class
- preserve parsed lists from CLI for later GitHub use
- test parsing multiple `--exclude` options

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688cb1213c148325a11d0a2b3ca8e0a6