### PR TITLE
Fix Windows compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,12 @@ provided scripts:
 ./scripts/compile_win.ps1    # Windows
 ```
 Run the matching `install_*` script for your platform first to install system
-packages like **libcurl**, **sqlite3** and **ncurses**. Then use `update_libs.sh` (or
-`update_libs.ps1` on Windows) to populate the `libs` directory with clones of
-**CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, **spdlog**, **curl**,
-the SQLite amalgamation and **PDCurses** before compiling. The Windows compile
+packages like **libcurl**, **sqlite3** and **ncurses**. On Windows the script
+also installs **pkgconfiglite** which is used by `compile_win.ps1` to locate
+libraries. Then use `update_libs.sh` (or `update_libs.ps1` on Windows) to
+populate the `libs` directory with clones of **CLI11**, **yaml-cpp**,
+**libyaml**, **nlohmann/json**, **spdlog**, **curl**, the SQLite amalgamation and
+**PDCurses** before compiling. The Windows compile
 script links the application statically so the resulting binary has no runtime
 library dependencies.
 

--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -8,5 +8,11 @@ $include = Join-Path $RootDir "include"
 $libsDir = Join-Path $RootDir "libs"
 $srcList = $srcFiles -join ' '
 $includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\pdcurses`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
-$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lpdcurses -o `"$BuildDir\autogithubpullmerge.exe`""
+$pkgFlags = $(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 pdcurses)
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "pkg-config failed to locate required libraries"
+    exit 1
+}
+
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList $pkgFlags -o `"$BuildDir\autogithubpullmerge.exe`""
 Invoke-Expression $cmd

--- a/scripts/install_win.ps1
+++ b/scripts/install_win.ps1
@@ -1,2 +1,2 @@
 # Install dependencies including pdcurses for the TUI
-choco install cmake git curl sqlite spdlog pdcurses
+choco install cmake git curl sqlite spdlog pdcurses pkgconfiglite


### PR DESCRIPTION
## Summary
- update Windows install script to include `pkgconfiglite`
- resolve libraries via `pkg-config` in `compile_win.ps1`
- document new requirement in README

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688cd0b1cf5483259e86b34f1d2f82c4