### PR TITLE
Fix Windows compile script

### DIFF
--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -1,12 +1,18 @@
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$RootDir = Join-Path $ScriptDir ".."
-$BuildDir = Join-Path $RootDir "build_gpp"
+$RootDir = Resolve-Path (Join-Path $ScriptDir '..')
+Set-Location $RootDir
+
+$BuildDir = Join-Path $RootDir 'build_gpp'
 New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
 
-$srcFiles = Get-ChildItem -Path (Join-Path $RootDir "src") -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
-$include = Join-Path $RootDir "include"
-$libsDir = Join-Path $RootDir "libs"
+$srcFiles = Get-ChildItem -Path (Join-Path $RootDir 'src') -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
 $srcList = $srcFiles -join ' '
+
+$include = Join-Path $RootDir 'include'
+$libsDir  = Join-Path $RootDir 'libs'
 $includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\pdcurses`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
-$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList -lcurl -lsqlite3 -lyaml-cpp -lyaml -lpdcurses -o `"$BuildDir\autogithubpullmerge.exe`""
+
+$libArgs = "-L`"$libsDir\curl\lib`" -L`"$libsDir\sqlite`" -L`"$libsDir\yaml-cpp\lib`" -L`"$libsDir\libyaml\lib`" -L`"$libsDir\pdcurses\lib`""
+
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList $libArgs -lcurl -lsqlite3 -lyaml-cpp -lyaml -lpdcurses -o `"$BuildDir\autogithubpullmerge.exe`""
 Invoke-Expression $cmd


### PR DESCRIPTION
## Summary
- fix compile_win.ps1 to use project root as working directory
- add explicit library search paths for bundled libs

## Testing
- `./scripts/update_libs.sh`
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688cd88f445c8325a2908f0156e11687