### PR TITLE
Fix Windows compile paths

### DIFF
--- a/scripts/compile_win.ps1
+++ b/scripts/compile_win.ps1
@@ -1,18 +1,35 @@
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-$RootDir = Resolve-Path (Join-Path $ScriptDir '..')
-Set-Location $RootDir
+$RootDir   = Resolve-Path (Join-Path $ScriptDir '..')
 
-$BuildDir = Join-Path $RootDir 'build_gpp'
-New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null
+$BuildDir  = Join-Path $RootDir 'build_gpp'
+New-Item -ItemType Directory -Path $BuildDir -Force | Out-Null | Out-Null
 
-$srcFiles = Get-ChildItem -Path (Join-Path $RootDir 'src') -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
-$srcList = $srcFiles -join ' '
+$srcFiles   = Get-ChildItem -Path (Join-Path $RootDir 'src') -Filter *.cpp -Recurse | ForEach-Object { $_.FullName }
+$includeDir = Join-Path $RootDir 'include'
+$libsDir    = Join-Path $RootDir 'libs'
 
-$include = Join-Path $RootDir 'include'
-$libsDir  = Join-Path $RootDir 'libs'
-$includeArgs = "-I`"$include`" -I`"$libsDir\CLI11\include`" -I`"$libsDir\json\include`" -I`"$libsDir\spdlog\include`" -I`"$libsDir\yaml-cpp\include`" -I`"$libsDir\libyaml\include`" -I`"$libsDir\pdcurses`" -I`"$libsDir\curl\include`" -I`"$libsDir\sqlite`""
+$includeArgs = @(
+    "-I$includeDir",
+    "-I$libsDir\CLI11\include",
+    "-I$libsDir\json\include",
+    "-I$libsDir\spdlog\include",
+    "-I$libsDir\yaml-cpp\include",
+    "-I$libsDir\libyaml\include",
+    "-I$libsDir\pdcurses",
+    "-I$libsDir\curl\include",
+    "-I$libsDir\sqlite"
+) -join ' '
 
-$libArgs = "-L`"$libsDir\curl\lib`" -L`"$libsDir\sqlite`" -L`"$libsDir\yaml-cpp\lib`" -L`"$libsDir\libyaml\lib`" -L`"$libsDir\pdcurses\lib`""
+$libArgs = @(
+    "-L$libsDir\curl\lib",
+    "-L$libsDir\sqlite",
+    "-L$libsDir\yaml-cpp\lib",
+    "-L$libsDir\libyaml\lib",
+    "-L$libsDir\pdcurses\lib"
+) -join ' '
 
-$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $srcList $libArgs -lcurl -lsqlite3 -lyaml-cpp -lyaml -lpdcurses -o `"$BuildDir\autogithubpullmerge.exe`""
+$cmd = "g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE $includeArgs $($srcFiles -join ' ') $libArgs -lcurl -lsqlite3 -lyaml-cpp -lyaml -lpdcurses -o `"$BuildDir\autogithubpullmerge.exe`""
+
+Push-Location $RootDir
 Invoke-Expression $cmd
+Pop-Location


### PR DESCRIPTION
## Summary
- improve path handling in `compile_win.ps1`

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688cddc270b88325b7077c564d3d57b6