### PR TITLE
Add include-merged CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ API keys can be provided in several ways:
 - `--max-request-rate` limits the maximum number of GitHub requests per minute
   using a token bucket algorithm. When polling is enabled a background worker
   thread periodically invokes the GitHub API.
+- `--include-merged` lists merged pull requests in addition to open ones.
 
 ## Examples
 

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -21,6 +21,7 @@ to build the project on supported platforms.
 - `--api-key-url`/`--api-key-url-user`/`--api-key-url-password` - fetch tokens
   from a remote URL with optional basic authentication.
 - `--api-key-file` - load tokens from a local YAML or JSON file.
+- `--include-merged` - show merged pull requests when listing.
 - `--poll-interval` - how often to poll GitHub (seconds, `0` disables).
 - `--max-request-rate` - limit GitHub requests per minute. When polling is
   enabled a worker thread fetches pull requests at the configured interval.

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -13,13 +13,14 @@ struct CliOptions {
   std::string log_level = "info"; ///< Logging verbosity level
   std::vector<std::string> include_repos; ///< Repositories to include
   std::vector<std::string> exclude_repos; ///< Repositories to exclude
+  bool include_merged = false;            ///< Include merged pull requests
   std::vector<std::string> api_keys;      ///< Personal access tokens
   bool api_key_from_stream = false;       ///< Read tokens from stdin
   std::string api_key_url;                ///< Remote URL with tokens
   std::string api_key_url_user;           ///< Basic auth user
   std::string api_key_url_password;       ///< Basic auth password
   std::string api_key_file;               ///< File containing tokens
-  std::string history_db = "history.db"; ///< SQLite history database path
+  std::string history_db = "history.db";  ///< SQLite history database path
   int poll_interval = 0;                  ///< Polling interval in seconds
   int max_request_rate = 60;              ///< Max requests per minute
 };

--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -79,7 +79,8 @@ public:
    * @return List of pull request summaries
    */
   std::vector<PullRequest> list_pull_requests(const std::string &owner,
-                                              const std::string &repo);
+                                              const std::string &repo,
+                                              bool include_merged = false);
 
   /**
    * Merge a pull request.

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -116,6 +116,8 @@ CliOptions parse_cli(int argc, char **argv) {
                  "Repository to exclude; repeatable")
       ->type_name("REPO")
       ->expected(-1);
+  app.add_flag("--include-merged", options.include_merged,
+               "Include merged pull requests");
   app.add_option("--api-key", options.api_keys,
                  "Personal access token (repeatable, not recommended)")
       ->type_name("TOKEN")

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -29,7 +29,8 @@ std::string CurlHttpClient::get(const std::string &url,
   for (const auto &h : headers) {
     header_list = curl_slist_append(header_list, h.c_str());
   }
-  header_list = curl_slist_append(header_list, "User-Agent: autogithubpullmerge");
+  header_list =
+      curl_slist_append(header_list, "User-Agent: autogithubpullmerge");
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
   CURLcode res = curl_easy_perform(curl);
   curl_slist_free_all(header_list);
@@ -56,7 +57,8 @@ std::string CurlHttpClient::put(const std::string &url, const std::string &data,
   for (const auto &h : headers) {
     header_list = curl_slist_append(header_list, h.c_str());
   }
-  header_list = curl_slist_append(header_list, "User-Agent: autogithubpullmerge");
+  header_list =
+      curl_slist_append(header_list, "User-Agent: autogithubpullmerge");
   curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
   CURLcode res = curl_easy_perform(curl);
   curl_slist_free_all(header_list);
@@ -94,13 +96,16 @@ bool GitHubClient::repo_allowed(const std::string &repo) const {
 
 std::vector<PullRequest>
 GitHubClient::list_pull_requests(const std::string &owner,
-                                 const std::string &repo) {
+                                 const std::string &repo, bool include_merged) {
   if (!repo_allowed(repo)) {
     return {};
   }
   enforce_delay();
   std::string url =
       "https://api.github.com/repos/" + owner + "/" + repo + "/pulls";
+  if (include_merged) {
+    url += "?state=all";
+  }
   std::vector<std::string> headers = {"Authorization: token " + token_,
                                       "Accept: application/vnd.github+json"};
   std::string resp = http_->get(url, headers);

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -95,5 +95,10 @@ int main() {
   agpm::CliOptions opts12 = agpm::parse_cli(3, argv12);
   assert(opts12.history_db == "my.db");
 
+  char merged_flag[] = "--include-merged";
+  char *argv13[] = {prog, merged_flag};
+  agpm::CliOptions opts13 = agpm::parse_cli(2, argv13);
+  assert(opts13.include_merged);
+
   return 0;
 }

--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -38,6 +38,14 @@ int main() {
   assert(prs[0].number == 1);
   assert(prs[0].title == "Test");
 
+  auto mock_include = std::make_unique<MockHttpClient>();
+  mock_include->response = "[]";
+  MockHttpClient *raw_inc = mock_include.get();
+  GitHubClient client_inc("token",
+                          std::unique_ptr<HttpClient>(mock_include.release()));
+  client_inc.list_pull_requests("owner", "repo", true);
+  assert(raw_inc->last_url.find("state=all") != std::string::npos);
+
   // Test merging pull requests
   auto mock2 = std::make_unique<MockHttpClient>();
   mock2->response = "{\"merged\":true}";


### PR DESCRIPTION
## Summary
- add `include_merged` option to `CliOptions`
- parse `--include-merged` flag in CLI
- allow listing merged PRs through `GitHubClient::list_pull_requests`
- update docs and usage summary
- test new CLI flag and GitHub client behaviour

## Testing
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688cf3d384008325aab5d2b973219869