### PR TITLE
Add pr-limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ API keys can be provided in several ways:
 - `--max-request-rate` limits the maximum number of GitHub requests per minute
   using a token bucket algorithm. When polling is enabled a background worker
   thread periodically invokes the GitHub API.
+- `--pr-limit` limits how many pull requests to fetch when listing.
 - `--include-merged` lists merged pull requests in addition to open ones.
 - `--poll-prs` polls only pull requests.
 - `--poll-stray-branches` polls only stray branches.

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -27,6 +27,7 @@ to build the project on supported platforms.
 - `--poll-interval` - how often to poll GitHub (seconds, `0` disables).
 - `--max-request-rate` - limit GitHub requests per minute. When polling is
   enabled a worker thread fetches pull requests at the configured interval.
+- `--pr-limit` - limit how many pull requests to fetch when listing.
 
 ## Configuration File Examples
 

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -25,6 +25,7 @@ struct CliOptions {
   int max_request_rate = 60;              ///< Max requests per minute
   bool poll_prs_only = false;             ///< Only poll pull requests
   bool poll_stray_only = false;           ///< Only poll stray branches
+  int pr_limit{50};                       ///< Number of pull requests to fetch
 };
 
 /**

--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -80,7 +80,8 @@ public:
    */
   std::vector<PullRequest> list_pull_requests(const std::string &owner,
                                               const std::string &repo,
-                                              bool include_merged = false);
+                                              bool include_merged = false,
+                                              int per_page = 50);
 
   /**
    * Merge a pull request.

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -148,6 +148,10 @@ CliOptions parse_cli(int argc, char **argv) {
                  "Maximum requests per minute")
       ->type_name("RATE")
       ->default_val("60");
+  app.add_option("--pr-limit", options.pr_limit,
+                 "Number of pull requests to fetch")
+      ->type_name("N")
+      ->default_val("50");
   app.add_flag("--poll-prs", options.poll_prs_only, "Only poll pull requests");
   app.add_flag("--poll-stray-branches", options.poll_stray_only,
                "Only poll stray branches");

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -96,15 +96,25 @@ bool GitHubClient::repo_allowed(const std::string &repo) const {
 
 std::vector<PullRequest>
 GitHubClient::list_pull_requests(const std::string &owner,
-                                 const std::string &repo, bool include_merged) {
+                                 const std::string &repo, bool include_merged,
+                                 int per_page) {
   if (!repo_allowed(repo)) {
     return {};
   }
   enforce_delay();
   std::string url =
       "https://api.github.com/repos/" + owner + "/" + repo + "/pulls";
+  std::string query;
   if (include_merged) {
-    url += "?state=all";
+    query += "state=all";
+  }
+  if (per_page > 0) {
+    if (!query.empty())
+      query += "&";
+    query += "per_page=" + std::to_string(per_page);
+  }
+  if (!query.empty()) {
+    url += "?" + query;
   }
   std::vector<std::string> headers = {"Authorization: token " + token_,
                                       "Accept: application/vnd.github+json"};

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -110,5 +110,15 @@ int main() {
   agpm::CliOptions opts15 = agpm::parse_cli(2, argv15);
   assert(opts15.poll_stray_only);
 
+  char limit_flag[] = "--pr-limit";
+  char limit_val[] = "25";
+  char *argv16[] = {prog, limit_flag, limit_val};
+  agpm::CliOptions opts16 = agpm::parse_cli(3, argv16);
+  assert(opts16.pr_limit == 25);
+
+  char *argv17[] = {prog};
+  agpm::CliOptions opts17 = agpm::parse_cli(1, argv17);
+  assert(opts17.pr_limit == 50);
+
   return 0;
 }

--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -46,6 +46,14 @@ int main() {
   client_inc.list_pull_requests("owner", "repo", true);
   assert(raw_inc->last_url.find("state=all") != std::string::npos);
 
+  auto mock_limit = std::make_unique<MockHttpClient>();
+  mock_limit->response = "[]";
+  MockHttpClient *raw_limit = mock_limit.get();
+  GitHubClient client_limit("token",
+                            std::unique_ptr<HttpClient>(mock_limit.release()));
+  client_limit.list_pull_requests("owner", "repo", false, 10);
+  assert(raw_limit->last_url.find("per_page=10") != std::string::npos);
+
   // Test merging pull requests
   auto mock2 = std::make_unique<MockHttpClient>();
   mock2->response = "{\"merged\":true}";


### PR DESCRIPTION
## Summary
- add `pr_limit` to `CliOptions`
- parse `--pr-limit` in CLI
- limit `list_pull_requests` via new `per_page` argument
- document the new option
- update unit tests

## Testing
- `cmake -S . -B build -DBUILD_SHARED_LIBS=OFF`
- `cmake --build build -j4`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688d22d75c548325954d82036245e449