### PR TITLE
Add PR age filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ API keys can be provided in several ways:
   using a token bucket algorithm. When polling is enabled a background worker
   thread periodically invokes the GitHub API.
 - `--pr-limit` limits how many pull requests to fetch when listing.
+- `--pr-since` filters pull requests newer than the given duration
+  (e.g. `30m`, `2h`, `1d`).
 - `--include-merged` lists merged pull requests in addition to open ones.
 - `--poll-prs` polls only pull requests.
 - `--poll-stray-branches` polls only stray branches.

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -28,6 +28,8 @@ to build the project on supported platforms.
 - `--max-request-rate` - limit GitHub requests per minute. When polling is
   enabled a worker thread fetches pull requests at the configured interval.
 - `--pr-limit` - limit how many pull requests to fetch when listing.
+- `--pr-since` - only list pull requests newer than the given duration
+  (e.g. `30m`, `2h`, `1d`).
 
 ## Configuration File Examples
 

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -1,6 +1,7 @@
 #ifndef AUTOGITHUBPULLMERGE_CLI_HPP
 #define AUTOGITHUBPULLMERGE_CLI_HPP
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,7 @@ struct CliOptions {
   bool poll_prs_only = false;             ///< Only poll pull requests
   bool poll_stray_only = false;           ///< Only poll stray branches
   int pr_limit{50};                       ///< Number of pull requests to fetch
+  std::chrono::seconds pr_since{0}; ///< Only list pull requests newer than this
 };
 
 /**

--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -78,10 +78,10 @@ public:
    * @param repo Repository name
    * @return List of pull request summaries
    */
-  std::vector<PullRequest> list_pull_requests(const std::string &owner,
-                                              const std::string &repo,
-                                              bool include_merged = false,
-                                              int per_page = 50);
+  std::vector<PullRequest>
+  list_pull_requests(const std::string &owner, const std::string &repo,
+                     bool include_merged = false, int per_page = 50,
+                     std::chrono::seconds since = std::chrono::seconds{0});
 
   /**
    * Merge a pull request.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,10 @@ add_executable(test_poller test_poller.cpp)
 target_link_libraries(test_poller PRIVATE autogithubpullmerge_lib)
 add_test(NAME poller_test COMMAND test_poller)
 
+add_executable(test_pr_since test_pr_since.cpp)
+target_link_libraries(test_pr_since PRIVATE autogithubpullmerge_lib)
+add_test(NAME pr_since_test COMMAND test_pr_since)
+
 add_executable(test_cli_tokens test_cli_tokens.cpp)
 target_link_libraries(test_cli_tokens PRIVATE autogithubpullmerge_lib)
 add_test(NAME cli_tokens_test COMMAND test_cli_tokens)

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -1,5 +1,6 @@
 #include "cli.hpp"
 #include <cassert>
+#include <chrono>
 #include <fstream>
 
 int main() {
@@ -119,6 +120,16 @@ int main() {
   char *argv17[] = {prog};
   agpm::CliOptions opts17 = agpm::parse_cli(1, argv17);
   assert(opts17.pr_limit == 50);
+
+  char since_flag[] = "--pr-since";
+  char since_val[] = "2h";
+  char *argv18[] = {prog, since_flag, since_val};
+  agpm::CliOptions opts18 = agpm::parse_cli(3, argv18);
+  assert(opts18.pr_since == std::chrono::hours(2));
+
+  char *argv19[] = {prog};
+  agpm::CliOptions opts19 = agpm::parse_cli(1, argv19);
+  assert(opts19.pr_since == std::chrono::seconds(0));
 
   return 0;
 }

--- a/tests/test_pr_since.cpp
+++ b/tests/test_pr_since.cpp
@@ -1,0 +1,51 @@
+#include "github_client.hpp"
+#include <cassert>
+#include <chrono>
+#include <ctime>
+#include <string>
+
+using namespace agpm;
+
+class TimeHttpClient : public HttpClient {
+public:
+  std::string response;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return response;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+};
+
+int main() {
+  using namespace std::chrono;
+  auto now = system_clock::now();
+  auto recent = now - minutes(30);
+  auto old = now - hours(5);
+  auto recent_t = system_clock::to_time_t(recent);
+  auto old_t = system_clock::to_time_t(old);
+  char recent_buf[32];
+  char old_buf[32];
+  std::strftime(recent_buf, sizeof(recent_buf), "%Y-%m-%dT%H:%M:%SZ",
+                std::gmtime(&recent_t));
+  std::strftime(old_buf, sizeof(old_buf), "%Y-%m-%dT%H:%M:%SZ",
+                std::gmtime(&old_t));
+  std::string resp =
+      std::string("[{\"number\":1,\"title\":\"Old\",\"created_at\":\"") +
+      old_buf + "\"},{\"number\":2,\"title\":\"New\",\"created_at\":\"" +
+      recent_buf + "\"}]";
+  auto http = std::make_unique<TimeHttpClient>();
+  http->response = resp;
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  auto prs = client.list_pull_requests("me", "repo", false, 50, hours(1));
+  assert(prs.size() == 1);
+  assert(prs[0].number == 2);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- parse `--pr-since` CLI option
- filter pull requests newer than the given duration
- test duration parsing and filtering
- document `--pr-since`

## Testing
- `scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688d295f949c832590d9bc9d058f9449