### PR TITLE
Fix Windows curl extraction

### DIFF
--- a/scripts/update_libs.bat
+++ b/scripts/update_libs.bat
@@ -21,7 +21,7 @@ if not exist "!CURL_DIR!" mkdir "!CURL_DIR!"
 if not exist "!CURL_DIR!\lib\libcurl.a" (
     curl -L %CURL_URL% -o "!CURL_DIR!\%CURL_ZIP%" || goto :eof
     powershell -Command "Expand-Archive -Path '!CURL_DIR!\%CURL_ZIP%' -DestinationPath '!CURL_DIR!' -Force" || goto :eof
-    move /y "!CURL_DIR!\curl-%CURL_VER%-win64-mingw\*" "!CURL_DIR!" >nul
+    powershell -Command "Copy-Item -Path '!CURL_DIR!\curl-%CURL_VER%-win64-mingw\*' -Destination '!CURL_DIR!' -Recurse -Force" || goto :eof
     rmdir /s /q "!CURL_DIR!\curl-%CURL_VER%-win64-mingw"
     del "!CURL_DIR!\%CURL_ZIP%"
 )


### PR DESCRIPTION
## Summary
- ensure curl archive is fully extracted on Windows

## Testing
- `scripts/update_libs.sh`
- `scripts/compile_linux.sh` *(fails: Package yaml-cpp was not found...)*

------
https://chatgpt.com/codex/tasks/task_e_688ddb3ad7a08325a06e33a33489f6e2