### PR TITLE
build: route dependencies through install dirs

### DIFF
--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -6,8 +6,36 @@ BUILD_DIR="${ROOT_DIR}/build_gpp"
 mkdir -p "$BUILD_DIR"
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
-INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${LIBS_DIR}/yaml-cpp/include\" -I\"${LIBS_DIR}/libyaml/include\" -I\"${LIBS_DIR}/pdcurses\" -I\"${LIBS_DIR}/curl/include\""
+
+# Dependency locations following the *_install convention
+YAMLCPP_INC="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/include"
+YAMLCPP_LIB="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib"
+CURL_INC="${LIBS_DIR}/curl/curl_install/include"
+CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
+
+# Ensure headers exist for critical dependencies
+[[ -f "${YAMLCPP_INC}/yaml-cpp/yaml.h" ]] || {
+    echo "[ERROR] yaml-cpp headers not found at ${YAMLCPP_INC}" >&2
+    exit 1
+}
+[[ -f "${CURL_INC}/curl/curl.h" ]] || {
+    echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
+    exit 1
+}
+
+INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${YAMLCPP_INC}\" -I\"${CURL_INC}\" -I\"${LIBS_DIR}/sqlite\""
+
+[[ -f "${YAMLCPP_LIB}/libyaml-cpp.a" ]] || {
+    echo "[ERROR] libyaml-cpp.a not found at ${YAMLCPP_LIB}" >&2
+    exit 1
+}
+[[ -f "${CURL_LIB}/libcurl.a" ]] || {
+    echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
+    exit 1
+}
 
 g++ -std=c++20 -Wall -Wextra -O2 $INCLUDE_FLAGS $SRC_FILES \
-	$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses) -pthread \
-	-o "$BUILD_DIR/autogithubpullmerge"
+    -L"${YAMLCPP_LIB}" -lyaml-cpp \
+    -L"${CURL_LIB}" -lcurl \
+    $(pkg-config --cflags --libs sqlite3 ncurses) -pthread \
+    -o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -9,27 +9,54 @@ mkdir -p "$BUILD_DIR"
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
 
+# Dependency locations following the *_install convention
+YAMLCPP_INC="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/include"
+YAMLCPP_LIB="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib"
+CURL_INC="${LIBS_DIR}/curl/curl_install/include"
+CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
+
+# Ensure required headers exist
+[[ -f "${YAMLCPP_INC}/yaml-cpp/yaml.h" ]] || {
+    echo "[ERROR] yaml-cpp headers not found at ${YAMLCPP_INC}" >&2
+    exit 1
+}
+[[ -f "${CURL_INC}/curl/curl.h" ]] || {
+    echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
+    exit 1
+}
+
 # Include directories for project headers and third-party libraries
 INCLUDE_FLAGS=(
     "-I${ROOT_DIR}/include"
     "-I${LIBS_DIR}/CLI11/include"
     "-I${LIBS_DIR}/json/include"
     "-I${LIBS_DIR}/spdlog/include"
-    "-I${LIBS_DIR}/yaml-cpp/include"
-    "-I${LIBS_DIR}/libyaml/include"
-    "-I${LIBS_DIR}/pdcurses"
-    "-I${LIBS_DIR}/curl/include"
+    "-I${YAMLCPP_INC}"
+    "-I${CURL_INC}"
+    "-I${LIBS_DIR}/sqlite"
 )
 
 if command -v pkg-config >/dev/null; then
-    PKG_FLAGS=$(pkg-config --cflags --libs yaml-cpp yaml-0.1 libcurl sqlite3 ncurses)
+    PKG_FLAGS=$(pkg-config --cflags --libs sqlite3 ncurses)
 else
     echo "pkg-config not found, using fallback flags"
-    PKG_FLAGS="-lyaml-cpp -lyaml -lcurl -lsqlite3 -lncurses"
+    PKG_FLAGS="-lsqlite3 -lncurses"
 fi
+
+[[ -f "${YAMLCPP_LIB}/libyaml-cpp.a" ]] || {
+    echo "[ERROR] libyaml-cpp.a not found at ${YAMLCPP_LIB}" >&2
+    exit 1
+}
+[[ -f "${CURL_LIB}/libcurl.a" ]] || {
+    echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
+    exit 1
+}
 
 CPU_CORES=$(sysctl -n hw.ncpu)
 
 # shellcheck disable=SC2068
-g++ -std=c++20 -Wall -Wextra -O2 ${INCLUDE_FLAGS[@]} $SRC_FILES $PKG_FLAGS -pthread \
+g++ -std=c++20 -Wall -Wextra -O2 ${INCLUDE_FLAGS[@]} $SRC_FILES \
+    -L"${YAMLCPP_LIB}" -lyaml-cpp \
+    -L"${CURL_LIB}" -lcurl \
+    $PKG_FLAGS -pthread \
     -o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -28,22 +28,43 @@ rem ---------------------------------------------------------------------------
 rem  Include directories
 rem ---------------------------------------------------------------------------
 set "LIBS_DIR=%ROOT_DIR%\libs"
+
+rem Dependency include and lib directories produced by their install steps
+set "YAMLCPP_INC=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\include"
+set "YAMLCPP_LIB=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\libyaml-cpp.a"
+set "CURL_INC=%LIBS_DIR%\curl\curl_install\include"
+set "CURL_LIB=%LIBS_DIR%\curl\curl_install\lib\libcurl.a"
+set "PDCURSES_INC=%LIBS_DIR%\pdcurses\pdcurses_install\include"
+set "PDCURSES_LIB=%LIBS_DIR%\pdcurses\pdcurses_install\lib\pdcurses.a"
+
+rem Verify headers exist for required dependencies
+if not exist "%YAMLCPP_INC%\yaml-cpp\yaml.h" (
+    echo [ERROR] yaml-cpp headers not found at %YAMLCPP_INC%
+    exit /b 1
+)
+if not exist "%CURL_INC%\curl\curl.h" (
+    echo [ERROR] curl headers not found at %CURL_INC%
+    exit /b 1
+)
+if not exist "%PDCURSES_INC%\curses.h" (
+    echo [ERROR] pdcurses headers not found at %PDCURSES_INC%
+    exit /b 1
+)
+
 set INCLUDE_ARGS=^
   -I"%ROOT_DIR%\include" ^
   -I"%LIBS_DIR%\CLI11\include" ^
   -I"%LIBS_DIR%\json\include" ^
   -I"%LIBS_DIR%\spdlog\include" ^
-  -I"%LIBS_DIR%\yaml-cpp\include" ^
-  -I"%LIBS_DIR%\pdcurses" ^
-  -I"%LIBS_DIR%\curl\include" ^
+  -I"%YAMLCPP_INC%" ^
+  -I"%PDCURSES_INC%" ^
+  -I"%CURL_INC%" ^
   -I"%LIBS_DIR%\sqlite"
 
 rem ---------------------------------------------------------------------------
+rem ---------------------------------------------------------------------------
 rem  Library locations (expect static libs in these folders)
 rem ---------------------------------------------------------------------------
-set "CURL_LIB=%LIBS_DIR%\curl\lib\libcurl.a"
-set "YAMLCPP_LIB=%LIBS_DIR%\yaml-cpp\lib\libyaml-cpp.a"
-set "PDCURSES_LIB=%LIBS_DIR%\pdcurses\lib\pdcurses.a"
 set LIB_ARGS="%CURL_LIB%" "%YAMLCPP_LIB%" "%PDCURSES_LIB%"
 
 if not exist "%CURL_LIB%" (

--- a/scripts/update_libs.sh
+++ b/scripts/update_libs.sh
@@ -21,6 +21,26 @@ clone_or_update https://github.com/nlohmann/json.git json
 clone_or_update https://github.com/gabime/spdlog.git spdlog
 clone_or_update https://github.com/curl/curl.git curl
 
+# Build and install yaml-cpp into a local install directory
+YAMLCPP_SRC="$LIBS_DIR/yaml-cpp"
+YAMLCPP_INSTALL="$YAMLCPP_SRC/yaml-cpp_install"
+if [ ! -f "$YAMLCPP_INSTALL/lib/libyaml-cpp.a" ]; then
+    cmake -S "$YAMLCPP_SRC" -B "$YAMLCPP_SRC/build" -DBUILD_SHARED_LIBS=OFF -DYAML_CPP_BUILD_TESTS=OFF \
+        -DCMAKE_INSTALL_PREFIX="$YAMLCPP_INSTALL"
+    cmake --build "$YAMLCPP_SRC/build" --config Release
+    cmake --install "$YAMLCPP_SRC/build"
+fi
+
+# Build and install curl into a local install directory
+CURL_SRC="$LIBS_DIR/curl"
+CURL_INSTALL="$CURL_SRC/curl_install"
+if [ ! -f "$CURL_INSTALL/lib/libcurl.a" ]; then
+    cmake -S "$CURL_SRC" -B "$CURL_SRC/build" -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF \
+        -DCMAKE_INSTALL_PREFIX="$CURL_INSTALL"
+    cmake --build "$CURL_SRC/build" --config Release
+    cmake --install "$CURL_SRC/build"
+fi
+
 # Download SQLite amalgamation containing sqlite3.c and sqlite3.h
 SQLITE_VER=3430000
 SQLITE_YEAR=2023


### PR DESCRIPTION
## Summary
- expect YAML-CPP, curl and pdcurses to use dedicated *_install folders
- validate presence of headers and libraries in custom compile scripts
- extend library update scripts to build and install dependencies into these folders

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e1e6a63a08325b4343a43608a4040