### PR TITLE
fix: improve mac dependency scripts

### DIFF
--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -4,10 +4,16 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 BUILD_DIR="${ROOT_DIR}/build_gpp"
+LIBS_DIR="${ROOT_DIR}/libs"
+
+# Ensure local dependencies are present; if missing, fetch and build them
+if [[ ! -f "${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib/libyaml-cpp.a" || ! -f "${LIBS_DIR}/curl/curl_install/lib/libcurl.a" ]]; then
+	"${SCRIPT_DIR}/update_libs.sh"
+fi
+
 mkdir -p "$BUILD_DIR"
 
 SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
-LIBS_DIR="${ROOT_DIR}/libs"
 
 # Dependency locations following the *_install convention
 YAMLCPP_INC="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/include"
@@ -17,46 +23,44 @@ CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
 
 # Ensure required headers exist
 [[ -f "${YAMLCPP_INC}/yaml-cpp/yaml.h" ]] || {
-    echo "[ERROR] yaml-cpp headers not found at ${YAMLCPP_INC}" >&2
-    exit 1
+	echo "[ERROR] yaml-cpp headers not found at ${YAMLCPP_INC}" >&2
+	exit 1
 }
 [[ -f "${CURL_INC}/curl/curl.h" ]] || {
-    echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
-    exit 1
+	echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
+	exit 1
 }
 
 # Include directories for project headers and third-party libraries
 INCLUDE_FLAGS=(
-    "-I${ROOT_DIR}/include"
-    "-I${LIBS_DIR}/CLI11/include"
-    "-I${LIBS_DIR}/json/include"
-    "-I${LIBS_DIR}/spdlog/include"
-    "-I${YAMLCPP_INC}"
-    "-I${CURL_INC}"
-    "-I${LIBS_DIR}/sqlite"
+	"-I${ROOT_DIR}/include"
+	"-I${LIBS_DIR}/CLI11/include"
+	"-I${LIBS_DIR}/json/include"
+	"-I${LIBS_DIR}/spdlog/include"
+	"-I${YAMLCPP_INC}"
+	"-I${CURL_INC}"
+	"-I${LIBS_DIR}/sqlite"
 )
 
 if command -v pkg-config >/dev/null; then
-    PKG_FLAGS=$(pkg-config --cflags --libs sqlite3 ncurses)
+	PKG_FLAGS=$(pkg-config --cflags --libs sqlite3 ncurses)
 else
-    echo "pkg-config not found, using fallback flags"
-    PKG_FLAGS="-lsqlite3 -lncurses"
+	echo "pkg-config not found, using fallback flags"
+	PKG_FLAGS="-lsqlite3 -lncurses"
 fi
 
 [[ -f "${YAMLCPP_LIB}/libyaml-cpp.a" ]] || {
-    echo "[ERROR] libyaml-cpp.a not found at ${YAMLCPP_LIB}" >&2
-    exit 1
+	echo "[ERROR] libyaml-cpp.a not found at ${YAMLCPP_LIB}" >&2
+	exit 1
 }
 [[ -f "${CURL_LIB}/libcurl.a" ]] || {
-    echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
-    exit 1
+	echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
+	exit 1
 }
-
-CPU_CORES=$(sysctl -n hw.ncpu)
 
 # shellcheck disable=SC2068
 g++ -std=c++20 -Wall -Wextra -O2 ${INCLUDE_FLAGS[@]} $SRC_FILES \
-    -L"${YAMLCPP_LIB}" -lyaml-cpp \
-    -L"${CURL_LIB}" -lcurl \
-    $PKG_FLAGS -pthread \
-    -o "$BUILD_DIR/autogithubpullmerge"
+	-L"${YAMLCPP_LIB}" -lyaml-cpp \
+	-L"${CURL_LIB}" -lcurl \
+	$PKG_FLAGS -pthread \
+	-o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 set -e
-# Install required packages including ncurses for the TUI
-brew install cmake git curl sqlite3 spdlog ncurses
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Install required packages including ncurses for the TUI and pkg-config for detection
+brew update
+brew install cmake git curl sqlite3 spdlog ncurses pkg-config
+
+# Fetch and build local third-party dependencies into the libs directory
+"${SCRIPT_DIR}/update_libs.sh"


### PR DESCRIPTION
## Summary
- ensure mac install script installs pkg-config and fetches dependencies
- have mac compile script auto-fetch dependencies before building

## Testing
- `bash -n scripts/compile_mac.sh scripts/install_mac.sh`
- `./scripts/compile_linux.sh` *(fails: yaml-cpp headers not found)*


------
https://chatgpt.com/codex/tasks/task_e_688e8a5e284c8325909f2e1ce27b22bd