### PR TITLE
Clarify include-merged flag default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ API keys can be provided in several ways:
 - `--pr-limit` limits how many pull requests to fetch when listing.
 - `--pr-since` filters pull requests newer than the given duration
   (e.g. `30m`, `2h`, `1d`).
-- `--include-merged` lists merged pull requests in addition to open ones.
+- `--include-merged` lists merged pull requests in addition to open ones (off by default).
 - `--poll-prs` polls only pull requests.
 - `--poll-stray-branches` polls only stray branches.
 - `--auto-reject-dirty` closes stray branches that have diverged.

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -21,7 +21,7 @@ to build the project on supported platforms.
 - `--api-key-url`/`--api-key-url-user`/`--api-key-url-password` - fetch tokens
   from a remote URL with optional basic authentication.
 - `--api-key-file` - load tokens from a local YAML or JSON file.
-- `--include-merged` - show merged pull requests when listing.
+- `--include-merged` - show merged pull requests when listing (off by default).
 - `--poll-prs` - only poll pull requests.
 - `--poll-stray-branches` - only poll stray branches.
 - `--auto-reject-dirty` - automatically close dirty stray branches.

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -14,7 +14,7 @@ struct CliOptions {
   std::string log_level = "info"; ///< Logging verbosity level
   std::vector<std::string> include_repos; ///< Repositories to include
   std::vector<std::string> exclude_repos; ///< Repositories to exclude
-  bool include_merged = false;            ///< Include merged pull requests
+  bool include_merged{false};             ///< Include merged pull requests
   std::vector<std::string> api_keys;      ///< Personal access tokens
   bool api_key_from_stream = false;       ///< Read tokens from stdin
   std::string api_key_url;                ///< Remote URL with tokens

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -29,6 +29,7 @@ int main() {
   char *argv5[] = {prog};
   agpm::CliOptions opts5 = agpm::parse_cli(1, argv5);
   assert(opts5.log_level == "info");
+  assert(!opts5.include_merged);
 
   char include_flag[] = "--include";
   char repo_a[] = "repoA";


### PR DESCRIPTION
## Summary
- ensure `include_merged` flag uses brace initialization
- test default state of `include_merged`
- document `--include-merged` default value

## Testing
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_688e8b3689c08325a9040c1b86fda802