### PR TITLE
fix: add libpsl dependency to build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ provided scripts:
 ./scripts/compile_win.bat    # Windows
 ```
 Run the matching `install_*` script for your platform first to install system
-packages like **libcurl**, **sqlite3** and **ncurses**. Then use `update_libs.sh` (or
+packages like **libcurl**, **libpsl**, **sqlite3** and **ncurses**. Then use `update_libs.sh` (or
 `update_libs.bat` on Windows) to populate the `libs` directory with clones of
 **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, **spdlog**, a prebuilt
 **curl** package, the SQLite amalgamation and **PDCurses** before compiling. The Windows compile

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="${SCRIPT_DIR}/.."
 BUILD_DIR="${ROOT_DIR}/build_gpp"
 mkdir -p "$BUILD_DIR"
-SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
+mapfile -t SRC_FILES < <(find "$ROOT_DIR/src" -name '*.cpp')
 LIBS_DIR="${ROOT_DIR}/libs"
 
 # Dependency locations following the *_install convention
@@ -15,27 +15,41 @@ CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
 
 # Ensure headers exist for critical dependencies
 [[ -f "${YAMLCPP_INC}/yaml-cpp/yaml.h" ]] || {
-    echo "[ERROR] yaml-cpp headers not found at ${YAMLCPP_INC}" >&2
-    exit 1
+	echo "[ERROR] yaml-cpp headers not found at ${YAMLCPP_INC}" >&2
+	exit 1
 }
 [[ -f "${CURL_INC}/curl/curl.h" ]] || {
-    echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
-    exit 1
+	echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
+	exit 1
 }
 
-INCLUDE_FLAGS="-I\"${ROOT_DIR}/include\" -I\"${LIBS_DIR}/CLI11/include\" -I\"${LIBS_DIR}/json/include\" -I\"${LIBS_DIR}/spdlog/include\" -I\"${YAMLCPP_INC}\" -I\"${CURL_INC}\" -I\"${LIBS_DIR}/sqlite\""
+INCLUDE_FLAGS=(
+	"-I${ROOT_DIR}/include"
+	"-I${LIBS_DIR}/CLI11/include"
+	"-I${LIBS_DIR}/json/include"
+	"-I${LIBS_DIR}/spdlog/include"
+	"-I${YAMLCPP_INC}"
+	"-I${CURL_INC}"
+	"-I${LIBS_DIR}/sqlite"
+)
+
+if command -v pkg-config >/dev/null; then
+	mapfile -t PKG_FLAGS < <(pkg-config --cflags --libs sqlite3 ncurses libpsl)
+else
+	PKG_FLAGS=(-lsqlite3 -lncurses -lpsl)
+fi
 
 [[ -f "${YAMLCPP_LIB}/libyaml-cpp.a" ]] || {
-    echo "[ERROR] libyaml-cpp.a not found at ${YAMLCPP_LIB}" >&2
-    exit 1
+	echo "[ERROR] libyaml-cpp.a not found at ${YAMLCPP_LIB}" >&2
+	exit 1
 }
 [[ -f "${CURL_LIB}/libcurl.a" ]] || {
-    echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
-    exit 1
+	echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
+	exit 1
 }
 
-g++ -std=c++20 -Wall -Wextra -O2 $INCLUDE_FLAGS $SRC_FILES \
-    -L"${YAMLCPP_LIB}" -lyaml-cpp \
-    -L"${CURL_LIB}" -lcurl \
-    $(pkg-config --cflags --libs sqlite3 ncurses) -pthread \
-    -o "$BUILD_DIR/autogithubpullmerge"
+g++ -std=c++20 -Wall -Wextra -O2 "${INCLUDE_FLAGS[@]}" "${SRC_FILES[@]}" \
+	-L"${YAMLCPP_LIB}" -lyaml-cpp \
+	-L"${CURL_LIB}" -lcurl \
+	"${PKG_FLAGS[@]}" -pthread \
+	-o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -13,7 +13,7 @@ fi
 
 mkdir -p "$BUILD_DIR"
 
-SRC_FILES=$(find "$ROOT_DIR/src" -name '*.cpp')
+mapfile -t SRC_FILES < <(find "$ROOT_DIR/src" -name '*.cpp')
 
 # Dependency locations following the *_install convention
 YAMLCPP_INC="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/include"
@@ -43,10 +43,10 @@ INCLUDE_FLAGS=(
 )
 
 if command -v pkg-config >/dev/null; then
-	PKG_FLAGS=$(pkg-config --cflags --libs sqlite3 ncurses)
+	mapfile -t PKG_FLAGS < <(pkg-config --cflags --libs sqlite3 ncurses libpsl)
 else
 	echo "pkg-config not found, using fallback flags"
-	PKG_FLAGS="-lsqlite3 -lncurses"
+	PKG_FLAGS=(-lsqlite3 -lncurses -lpsl)
 fi
 
 [[ -f "${YAMLCPP_LIB}/libyaml-cpp.a" ]] || {
@@ -58,9 +58,8 @@ fi
 	exit 1
 }
 
-# shellcheck disable=SC2068
-g++ -std=c++20 -Wall -Wextra -O2 ${INCLUDE_FLAGS[@]} $SRC_FILES \
+g++ -std=c++20 -Wall -Wextra -O2 "${INCLUDE_FLAGS[@]}" "${SRC_FILES[@]}" \
 	-L"${YAMLCPP_LIB}" -lyaml-cpp \
 	-L"${CURL_LIB}" -lcurl \
-	$PKG_FLAGS -pthread \
+	"${PKG_FLAGS[@]}" -pthread \
 	-o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -2,4 +2,4 @@
 set -e
 # Install packages required for building agpm including ncurses for the TUI
 sudo apt-get update
-sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libsqlite3-dev libspdlog-dev libncurses-dev
+sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libpsl-dev libsqlite3-dev libspdlog-dev libncurses-dev

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Install required packages including ncurses for the TUI and pkg-config for detection
 brew update
-brew install cmake git curl sqlite3 spdlog ncurses pkg-config
+brew install cmake git curl libpsl sqlite3 spdlog ncurses pkg-config
 
 # Fetch and build local third-party dependencies into the libs directory
 "${SCRIPT_DIR}/update_libs.sh"


### PR DESCRIPTION
## Summary
- ensure mac and linux install scripts install libpsl
- link libpsl when compiling with g++
- document libpsl requirement in README

## Testing
- `shellcheck scripts/install_mac.sh scripts/install_linux.sh scripts/compile_mac.sh scripts/compile_linux.sh`
- `cmake -S . -B build` *(failed: spdlog library not built with -fPIC)*

------
https://chatgpt.com/codex/tasks/task_e_688e8f9278f08325b4caa7b7c798613e