### PR TITLE
fix: improve windows build scripts

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -3,7 +3,29 @@ setlocal
 set "BUILD_DIR=build"
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
 cd /d "%BUILD_DIR%"
-cmake .. -G "NMake Makefiles" -DBUILD_SHARED_LIBS=OFF || exit /b 1
-cmake --build . -- /M || exit /b 1
+
+where nmake >nul 2>&1
+if %errorlevel%==0 (
+    set "GEN=NMake Makefiles"
+    set "BUILD_CMD=cmake --build . -- /M"
+) else (
+    where mingw32-make >nul 2>&1
+    if %errorlevel%==0 (
+        set "GEN=MinGW Makefiles"
+        set "BUILD_CMD=cmake --build ."
+    ) else (
+        where make >nul 2>&1
+        if %errorlevel%==0 (
+            set "GEN=Unix Makefiles"
+            set "BUILD_CMD=cmake --build ."
+        ) else (
+            echo [ERROR] No suitable build tool found. Install nmake, mingw32-make or make.
+            exit /b 1
+        )
+    )
+)
+
+cmake .. -G "%GEN%" -DBUILD_SHARED_LIBS=OFF || exit /b 1
+%BUILD_CMD% || exit /b 1
 ctest || exit /b 1
 endlocal

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -31,7 +31,8 @@ set "LIBS_DIR=%ROOT_DIR%\libs"
 
 rem Dependency include and lib directories produced by their install steps
 set "YAMLCPP_INC=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\include"
-set "YAMLCPP_LIB=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\libyaml-cpp.a"
+set "YAMLCPP_LIB_A=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\libyaml-cpp.a"
+set "YAMLCPP_LIB_LIB=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\yaml-cpp.lib"
 set "CURL_INC=%LIBS_DIR%\curl\curl_install\include"
 set "CURL_LIB=%LIBS_DIR%\curl\curl_install\lib\libcurl.a"
 set "PDCURSES_INC=%LIBS_DIR%\pdcurses\pdcurses_install\include"
@@ -61,6 +62,15 @@ if exist "%PDCURSES_LIB_A%" (
     exit /b 1
 )
 
+if exist "%YAMLCPP_LIB_A%" (
+    set "YAMLCPP_LIB=%YAMLCPP_LIB_A%"
+) else if exist "%YAMLCPP_LIB_LIB%" (
+    set "YAMLCPP_LIB=%YAMLCPP_LIB_LIB%"
+) else (
+    echo [ERROR] yaml-cpp library not found at %YAMLCPP_LIB_A% or %YAMLCPP_LIB_LIB%
+    exit /b 1
+)
+
 set INCLUDE_ARGS=^
   -I"%ROOT_DIR%\include" ^
   -I"%LIBS_DIR%\CLI11\include" ^
@@ -79,10 +89,6 @@ set LIB_ARGS="%CURL_LIB%" "%YAMLCPP_LIB%" "%PDCURSES_LIB%"
 
 if not exist "%CURL_LIB%" (
     echo [ERROR] libcurl.a not found at %CURL_LIB%
-    exit /b 1
-)
-if not exist "%YAMLCPP_LIB%" (
-    echo [ERROR] libyaml-cpp.a not found at %YAMLCPP_LIB%
     exit /b 1
 )
 if not exist "%PDCURSES_LIB%" (

--- a/scripts/update_libs.bat
+++ b/scripts/update_libs.bat
@@ -15,8 +15,16 @@ call :clone_or_update https://github.com/gabime/spdlog.git spdlog
 rem Build and install yaml-cpp into a local install directory
 set "YAMLCPP_SRC=!LIBS_DIR!\yaml-cpp"
 set "YAMLCPP_INSTALL=!YAMLCPP_SRC!\yaml-cpp_install"
-if not exist "!YAMLCPP_INSTALL!\lib\libyaml-cpp.a" (
-    cmake -S "!YAMLCPP_SRC!" -B "!YAMLCPP_SRC!\build" -DBUILD_SHARED_LIBS=OFF -DYAML_CPP_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="!YAMLCPP_INSTALL!" || goto :eof
+set "YAMLCPP_LIB_A=!YAMLCPP_INSTALL!\lib\libyaml-cpp.a"
+set "YAMLCPP_LIB_LIB=!YAMLCPP_INSTALL!\lib\yaml-cpp.lib"
+if not exist "!YAMLCPP_LIB_A!" if not exist "!YAMLCPP_LIB_LIB!" (
+    where mingw32-make >nul 2>&1
+    if not errorlevel 1 (
+        set "YAMLCPP_GEN=MinGW Makefiles"
+    ) else (
+        set "YAMLCPP_GEN=NMake Makefiles"
+    )
+    cmake -S "!YAMLCPP_SRC!" -B "!YAMLCPP_SRC!\build" -G "!YAMLCPP_GEN!" -DBUILD_SHARED_LIBS=OFF -DYAML_CPP_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX="!YAMLCPP_INSTALL!" || goto :eof
     cmake --build "!YAMLCPP_SRC!\build" --config Release || goto :eof
     cmake --install "!YAMLCPP_SRC!\build" || goto :eof
 )


### PR DESCRIPTION
## Summary
- build Windows CMake scripts with whichever tool is available
- allow compile_win.bat to link against yaml-cpp.lib or libyaml-cpp.a
- detect generator when building yaml-cpp in update_libs.bat

## Testing
- `./scripts/build_linux.sh` *(fails: Could not find a package configuration file provided by "spdlog")*

------
https://chatgpt.com/codex/tasks/task_e_689489d921008325986ae207a0297e17