### PR TITLE
Fix Windows linking for YAML and libcurl

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,27 +26,43 @@ endif()
 find_package(SQLite3 REQUIRED)
 find_package(Curses REQUIRED)
 
-add_library(autogithubpullmerge_lib
-            app.cpp
-            cli.cpp
-            config.cpp
-            config_manager.cpp
-            github_client.cpp
-            history.cpp
-            log.cpp
-            tui.cpp
-            poller.cpp
-            github_poller.cpp)
+add_library(
+  autogithubpullmerge_lib
+  app.cpp
+  cli.cpp
+  config.cpp
+  config_manager.cpp
+  github_client.cpp
+  history.cpp
+  log.cpp
+  tui.cpp
+  poller.cpp
+  github_poller.cpp)
 
-target_include_directories(autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include ${CURSES_INCLUDE_DIR})
+target_include_directories(
+  autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include
+                                 ${CURSES_INCLUDE_DIR})
 
-target_link_libraries(autogithubpullmerge_lib PUBLIC CLI11::CLI11 yaml-cpp
-                                              nlohmann_json::nlohmann_json
-                                              CURL::libcurl SQLite::SQLite3
-                                              spdlog::spdlog ${CURSES_LIBRARIES})
+target_link_libraries(
+  autogithubpullmerge_lib
+  PUBLIC CLI11::CLI11
+         yaml-cpp
+         nlohmann_json::nlohmann_json
+         CURL::libcurl
+         SQLite::SQLite3
+         spdlog::spdlog
+         ${CURSES_LIBRARIES})
 
 if(WIN32)
-  target_compile_definitions(autogithubpullmerge_lib PRIVATE YAML_CPP_STATIC_DEFINE)
+  target_compile_definitions(autogithubpullmerge_lib
+                             PRIVATE YAML_CPP_STATIC_DEFINE)
 endif()
 add_executable(autogithubpullmerge main.cpp)
-target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib)
+#
+# Explicitly link external libraries on the final executable.  While
+# autogithubpullmerge_lib already links against yaml-cpp and libcurl, transitive
+# dependencies are not always propagated reliably on some Windows builds.
+# Linking the required libraries here ensures the linker can resolve YAML and
+# libcurl symbols when building on Windows.
+target_link_libraries(autogithubpullmerge PRIVATE autogithubpullmerge_lib
+                                                  yaml-cpp CURL::libcurl)


### PR DESCRIPTION
## Summary
- explicitly link yaml-cpp and libcurl on the executable to resolve Windows linker errors

## Testing
- `cmake .. && cmake --build .` *(fails: Could not find spdlogConfig.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68948f1921b08325b2d284d9df89fd6c