### PR TITLE
fix: improve Windows compile script

### DIFF
--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -34,9 +34,12 @@ set "LIBS_DIR=%ROOT_DIR%\libs"
 rem Dependency include and lib directories produced by their install steps
 set "YAMLCPP_INC=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\include"
 set "YAMLCPP_LIB_A=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\libyaml-cpp.a"
+set "YAMLCPP_LIB_DLL_A=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\libyaml-cpp.dll.a"
 set "YAMLCPP_LIB_LIB=%LIBS_DIR%\yaml-cpp\yaml-cpp_install\lib\yaml-cpp.lib"
 set "CURL_INC=%LIBS_DIR%\curl\curl_install\include"
-set "CURL_LIB=%LIBS_DIR%\curl\curl_install\lib\libcurl.a"
+set "CURL_LIB_A=%LIBS_DIR%\curl\curl_install\lib\libcurl.a"
+set "CURL_LIB_DLL_A=%LIBS_DIR%\curl\curl_install\lib\libcurl.dll.a"
+set "CURL_LIB_LIB=%LIBS_DIR%\curl\curl_install\lib\curl.lib"
 set "PDCURSES_INC=%LIBS_DIR%\pdcurses\pdcurses_install\include"
 set "PDCURSES_LIB_A=%LIBS_DIR%\pdcurses\pdcurses_install\lib\pdcurses.a"
 set "PDCURSES_LIB_LIB=%LIBS_DIR%\pdcurses\pdcurses_install\lib\pdcurses.lib"
@@ -66,10 +69,24 @@ if exist "%PDCURSES_LIB_A%" (
 
 if exist "%YAMLCPP_LIB_A%" (
     set "YAMLCPP_LIB=%YAMLCPP_LIB_A%"
+) else if exist "%YAMLCPP_LIB_DLL_A%" (
+    set "YAMLCPP_LIB=%YAMLCPP_LIB_DLL_A%"
 ) else if exist "%YAMLCPP_LIB_LIB%" (
     set "YAMLCPP_LIB=%YAMLCPP_LIB_LIB%"
 ) else (
-    echo [ERROR] yaml-cpp library not found at %YAMLCPP_LIB_A% or %YAMLCPP_LIB_LIB%
+    echo [ERROR] yaml-cpp library not found at %YAMLCPP_LIB_A% or %YAMLCPP_LIB_DLL_A% or %YAMLCPP_LIB_LIB%
+    exit /b 1
+)
+
+if exist "%CURL_LIB_A%" (
+    set "CURL_LIB=%CURL_LIB_A%"
+    set "CURL_STATIC_DEF=-DCURL_STATICLIB"
+) else if exist "%CURL_LIB_DLL_A%" (
+    set "CURL_LIB=%CURL_LIB_DLL_A%"
+) else if exist "%CURL_LIB_LIB%" (
+    set "CURL_LIB=%CURL_LIB_LIB%"
+) else (
+    echo [ERROR] curl library not found at %CURL_LIB_A% or %CURL_LIB_DLL_A% or %CURL_LIB_LIB%
     exit /b 1
 )
 
@@ -87,10 +104,10 @@ rem ---------------------------------------------------------------------------
 rem ---------------------------------------------------------------------------
 rem  Library locations (expect static libs in these folders)
 rem ---------------------------------------------------------------------------
-set LIB_ARGS="%CURL_LIB%" "%YAMLCPP_LIB%" "%PDCURSES_LIB%"
+set LIB_ARGS="%CURL_LIB%" "%YAMLCPP_LIB%" "%PDCURSES_LIB%" -lws2_32 -lwinmm -lbcrypt -lcrypt32 -lwldap32
 
 if not exist "%CURL_LIB%" (
-    echo [ERROR] libcurl.a not found at %CURL_LIB%
+    echo [ERROR] curl library not found at %CURL_LIB%
     exit /b 1
 )
 if not exist "%PDCURSES_LIB%" (
@@ -98,10 +115,15 @@ if not exist "%PDCURSES_LIB%" (
     exit /b 1
 )
 
+set "LINK_FLAGS=-static -static-libgcc -static-libstdc++"
+if not "%CURL_LIB%"=="%CURL_LIB_A%" set "LINK_FLAGS="
+if not "%YAMLCPP_LIB%"=="%YAMLCPP_LIB_A%" set "LINK_FLAGS="
+if not "%PDCURSES_LIB%"=="%PDCURSES_LIB_A%" set "LINK_FLAGS="
+
 rem ---------------------------------------------------------------------------
 rem  Compile
 rem ---------------------------------------------------------------------------
-g++ -std=c++20 -Wall -Wextra -O2 -static -static-libgcc -static-libstdc++ -DYAML_CPP_STATIC_DEFINE %INCLUDE_ARGS% %SRC_LIST% %SQLITE_OBJ% %LIB_ARGS% -o "%BUILD_DIR%\autogithubpullmerge.exe"
+g++ -std=c++20 -Wall -Wextra -O2 %LINK_FLAGS% -DYAML_CPP_STATIC_DEFINE %CURL_STATIC_DEF% %INCLUDE_ARGS% %SRC_LIST% %SQLITE_OBJ% %LIB_ARGS% -o "%BUILD_DIR%\autogithubpullmerge.exe"
 
 endlocal
 


### PR DESCRIPTION
## Summary
- improve Windows compile script to detect static or dynamic libs
- add system library links and conditional compile flags

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog")*

------
https://chatgpt.com/codex/tasks/task_e_68949158632c8325a8d1801917de26d2