### PR TITLE
fix: add nghttp2 dependency

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -1,7 +1,7 @@
 This directory holds third-party dependencies used by autogithubpullmerge.
 Run `./scripts/update_libs.sh` or `./scripts/update_libs.bat` to clone or update
-third-party projects such as **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**, 
-**spdlog**, **curl**, **sqlite** and **ncurses**. After cloning, the SQLite
+third-party projects such as **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**,
+**spdlog**, **curl**, **nghttp2**, **sqlite** and **ncurses**. After cloning, the SQLite
 repository's `VERSION` file is renamed to `VERSION.txt` to prevent conflicts
 with the C++ `<version>` header. The contents of this folder are ignored by
 git so clones are not committed to the repository.

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -12,6 +12,8 @@ YAMLCPP_INC="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/include"
 YAMLCPP_LIB="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib"
 CURL_INC="${LIBS_DIR}/curl/curl_install/include"
 CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
+NGHTTP2_INC="${LIBS_DIR}/nghttp2/nghttp2_install/include"
+NGHTTP2_LIB="${LIBS_DIR}/nghttp2/nghttp2_install/lib"
 
 # Ensure headers exist for critical dependencies
 [[ -f "${YAMLCPP_INC}/yaml-cpp/yaml.h" ]] || {
@@ -19,8 +21,12 @@ CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
 	exit 1
 }
 [[ -f "${CURL_INC}/curl/curl.h" ]] || {
-	echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
-	exit 1
+        echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
+        exit 1
+}
+[[ -f "${NGHTTP2_INC}/nghttp2/nghttp2.h" ]] || {
+        echo "[ERROR] nghttp2 headers not found at ${NGHTTP2_INC}" >&2
+        exit 1
 }
 
 INCLUDE_FLAGS=(
@@ -28,9 +34,10 @@ INCLUDE_FLAGS=(
 	"-I${LIBS_DIR}/CLI11/include"
 	"-I${LIBS_DIR}/json/include"
 	"-I${LIBS_DIR}/spdlog/include"
-	"-I${YAMLCPP_INC}"
-	"-I${CURL_INC}"
-	"-I${LIBS_DIR}/sqlite"
+        "-I${YAMLCPP_INC}"
+        "-I${CURL_INC}"
+        "-I${NGHTTP2_INC}"
+        "-I${LIBS_DIR}/sqlite"
 )
 
 if command -v pkg-config >/dev/null; then
@@ -44,12 +51,17 @@ fi
 	exit 1
 }
 [[ -f "${CURL_LIB}/libcurl.a" ]] || {
-	echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
-	exit 1
+        echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
+        exit 1
+}
+[[ -f "${NGHTTP2_LIB}/libnghttp2.a" ]] || {
+        echo "[ERROR] libnghttp2.a not found at ${NGHTTP2_LIB}" >&2
+        exit 1
 }
 
 g++ -std=c++20 -Wall -Wextra -O2 "${INCLUDE_FLAGS[@]}" "${SRC_FILES[@]}" \
-	-L"${YAMLCPP_LIB}" -lyaml-cpp \
-	-L"${CURL_LIB}" -lcurl \
-	"${PKG_FLAGS[@]}" -pthread \
-	-o "$BUILD_DIR/autogithubpullmerge"
+        -L"${YAMLCPP_LIB}" -lyaml-cpp \
+        -L"${CURL_LIB}" -lcurl \
+        -L"${NGHTTP2_LIB}" -lnghttp2 \
+        "${PKG_FLAGS[@]}" -pthread \
+        -o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -7,8 +7,10 @@ BUILD_DIR="${ROOT_DIR}/build_gpp"
 LIBS_DIR="${ROOT_DIR}/libs"
 
 # Ensure local dependencies are present; if missing, fetch and build them
-if [[ ! -f "${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib/libyaml-cpp.a" || ! -f "${LIBS_DIR}/curl/curl_install/lib/libcurl.a" ]]; then
-	"${SCRIPT_DIR}/update_libs.sh"
+if [[ ! -f "${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib/libyaml-cpp.a" || \
+      ! -f "${LIBS_DIR}/curl/curl_install/lib/libcurl.a" || \
+      ! -f "${LIBS_DIR}/nghttp2/nghttp2_install/lib/libnghttp2.a" ]]; then
+        "${SCRIPT_DIR}/update_libs.sh"
 fi
 
 mkdir -p "$BUILD_DIR"
@@ -20,6 +22,8 @@ YAMLCPP_INC="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/include"
 YAMLCPP_LIB="${LIBS_DIR}/yaml-cpp/yaml-cpp_install/lib"
 CURL_INC="${LIBS_DIR}/curl/curl_install/include"
 CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
+NGHTTP2_INC="${LIBS_DIR}/nghttp2/nghttp2_install/include"
+NGHTTP2_LIB="${LIBS_DIR}/nghttp2/nghttp2_install/lib"
 
 # Ensure required headers exist
 [[ -f "${YAMLCPP_INC}/yaml-cpp/yaml.h" ]] || {
@@ -27,8 +31,12 @@ CURL_LIB="${LIBS_DIR}/curl/curl_install/lib"
 	exit 1
 }
 [[ -f "${CURL_INC}/curl/curl.h" ]] || {
-	echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
-	exit 1
+        echo "[ERROR] curl headers not found at ${CURL_INC}" >&2
+        exit 1
+}
+[[ -f "${NGHTTP2_INC}/nghttp2/nghttp2.h" ]] || {
+        echo "[ERROR] nghttp2 headers not found at ${NGHTTP2_INC}" >&2
+        exit 1
 }
 
 # Include directories for project headers and third-party libraries
@@ -37,9 +45,10 @@ INCLUDE_FLAGS=(
 	"-I${LIBS_DIR}/CLI11/include"
 	"-I${LIBS_DIR}/json/include"
 	"-I${LIBS_DIR}/spdlog/include"
-	"-I${YAMLCPP_INC}"
-	"-I${CURL_INC}"
-	"-I${LIBS_DIR}/sqlite"
+        "-I${YAMLCPP_INC}"
+        "-I${CURL_INC}"
+        "-I${NGHTTP2_INC}"
+        "-I${LIBS_DIR}/sqlite"
 )
 
 if command -v pkg-config >/dev/null; then
@@ -54,12 +63,17 @@ fi
 	exit 1
 }
 [[ -f "${CURL_LIB}/libcurl.a" ]] || {
-	echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
-	exit 1
+        echo "[ERROR] libcurl.a not found at ${CURL_LIB}" >&2
+        exit 1
+}
+[[ -f "${NGHTTP2_LIB}/libnghttp2.a" ]] || {
+        echo "[ERROR] libnghttp2.a not found at ${NGHTTP2_LIB}" >&2
+        exit 1
 }
 
 g++ -std=c++20 -Wall -Wextra -O2 "${INCLUDE_FLAGS[@]}" "${SRC_FILES[@]}" \
-	-L"${YAMLCPP_LIB}" -lyaml-cpp \
-	-L"${CURL_LIB}" -lcurl \
-	"${PKG_FLAGS[@]}" -pthread \
-	-o "$BUILD_DIR/autogithubpullmerge"
+        -L"${YAMLCPP_LIB}" -lyaml-cpp \
+        -L"${CURL_LIB}" -lcurl \
+        -L"${NGHTTP2_LIB}" -lnghttp2 \
+        "${PKG_FLAGS[@]}" -pthread \
+        -o "$BUILD_DIR/autogithubpullmerge"

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -69,6 +69,8 @@ set "CURL_INC=%LIBS_DIR%\curl\curl_install\include"
 set "CURL_LIB_A=%LIBS_DIR%\curl\curl_install\lib\libcurl.a"
 set "CURL_LIB_DLL_A=%LIBS_DIR%\curl\curl_install\lib\libcurl.dll.a"
 set "CURL_LIB_LIB=%LIBS_DIR%\curl\curl_install\lib\curl.lib"
+set "NGHTTP2_INC=%LIBS_DIR%\nghttp2\nghttp2_install\include"
+set "NGHTTP2_LIB_DIR=%LIBS_DIR%\nghttp2\nghttp2_install\lib"
 set "PDCURSES_INC=%LIBS_DIR%\pdcurses\pdcurses_install\include"
 set "PDCURSES_LIB_A=%LIBS_DIR%\pdcurses\pdcurses_install\lib\pdcurses.a"
 set "PDCURSES_LIB_LIB=%LIBS_DIR%\pdcurses\pdcurses_install\lib\pdcurses.lib"
@@ -80,6 +82,10 @@ if not exist "%YAMLCPP_INC%\yaml-cpp\yaml.h" (
 )
 if not exist "%CURL_INC%\curl\curl.h" (
     echo [ERROR] curl headers not found at %CURL_INC%
+    exit /b 1
+)
+if not exist "%NGHTTP2_INC%\nghttp2\nghttp2.h" (
+    echo [ERROR] nghttp2 headers not found at %NGHTTP2_INC%
     exit /b 1
 )
 if not exist "%PDCURSES_INC%\curses.h" (
@@ -118,6 +124,10 @@ if exist "%CURL_LIB_A%" (
     echo [ERROR] curl library not found at %CURL_LIB_A% or %CURL_LIB_DLL_A% or %CURL_LIB_LIB%
     exit /b 1
 )
+if not exist "%NGHTTP2_LIB_DIR%\libnghttp2.a" if not exist "%NGHTTP2_LIB_DIR%\libnghttp2.dll.a" if not exist "%NGHTTP2_LIB_DIR%\nghttp2.lib" (
+    echo [ERROR] nghttp2 library not found at %NGHTTP2_LIB_DIR%
+    exit /b 1
+)
 
 set INCLUDE_ARGS=^
   -I"%ROOT_DIR%\include" ^
@@ -126,7 +136,8 @@ set INCLUDE_ARGS=^
   -I"%LIBS_DIR%\spdlog\include" ^
   -I"%YAMLCPP_INC%" ^
   -I"%PDCURSES_INC%" ^
-  -I"%CURL_INC%" ^ 
+  -I"%CURL_INC%" ^
+  -I"%NGHTTP2_INC%" ^
   -I"%LIBS_DIR%\sqlite"
 
 echo Include args are: %INCLUDE_ARGS%
@@ -139,11 +150,13 @@ echo Getting lib args.
 
 rem Link against curl and its feature libraries statically
 set "CURL_LIBS_DIR=%LIBS_DIR%\curl\curl_install\lib"
+set "NGHTTP2_LIBS_DIR=%NGHTTP2_LIB_DIR%"
 
 set LIB_ARGS=^
   -L"%CURL_LIBS_DIR%" ^
+  -L"%NGHTTP2_LIBS_DIR%" ^
   -Wl,--start-group ^
-    -lcurl -lssh2 ^
+    -lcurl -lssh2 -lnghttp2 ^
     -lngtcp2_crypto_quictls -lngtcp2 -lnghttp3 ^
     -lssl -lcrypto ^
     -lbrotlidec -lbrotlicommon -lzstd -lz ^

--- a/scripts/update_libs.bat
+++ b/scripts/update_libs.bat
@@ -24,6 +24,7 @@ call :clone_or_update https://github.com/jbeder/yaml-cpp.git yaml-cpp
 call :clone_or_update https://github.com/yaml/libyaml.git libyaml
 call :clone_or_update https://github.com/nlohmann/json.git json
 call :clone_or_update https://github.com/gabime/spdlog.git spdlog
+call :clone_or_update https://github.com/nghttp2/nghttp2.git nghttp2
 call :clone_or_update https://github.com/wmcbrine/PDCurses.git pdcurses
 
 echo Repos checked and done.
@@ -43,6 +44,24 @@ cmake --build "!YAMLCPP_SRC!\build" --config Release || goto :eof
 cmake --install "!YAMLCPP_SRC!\build" || goto :eof
 
 echo Done yaml cpp.
+
+rem Build and install nghttp2 static library
+echo.
+echo Build and install nghttp2
+
+set "NGHTTP2_SRC=!LIBS_DIR!\nghttp2"
+set "NGHTTP2_INSTALL=!NGHTTP2_SRC!\nghttp2_install"
+set "NGHTTP2_LIB_A=!NGHTTP2_INSTALL!\lib\libnghttp2.a"
+set "NGHTTP2_LIB_LIB=!NGHTTP2_INSTALL!\lib\nghttp2.lib"
+
+del !NGHTTP2_SRC!\build\CMakeCache.txt 2>nul
+if not exist "!NGHTTP2_LIB_A!" if not exist "!NGHTTP2_LIB_LIB!" (
+    cmake -S "!NGHTTP2_SRC!" -B "!NGHTTP2_SRC!\build" -G "MinGW Makefiles" -DBUILD_SHARED_LIBS=OFF -DENABLE_EXAMPLES=OFF -DENABLE_HPACK_TOOLS=OFF -DENABLE_ASIO_LIB=OFF -DCMAKE_INSTALL_PREFIX="!NGHTTP2_INSTALL!"
+    cmake --build "!NGHTTP2_SRC!\build" --config Release || goto :eof
+    cmake --install "!NGHTTP2_SRC!\build" || goto :eof
+)
+
+echo Done nghttp2.
 
 rem Fetch prebuilt curl for Windows to obtain libcurl.a
 echo.

--- a/scripts/update_libs.sh
+++ b/scripts/update_libs.sh
@@ -20,6 +20,7 @@ clone_or_update https://github.com/yaml/libyaml.git libyaml
 clone_or_update https://github.com/nlohmann/json.git json
 clone_or_update https://github.com/gabime/spdlog.git spdlog
 clone_or_update https://github.com/curl/curl.git curl
+clone_or_update https://github.com/nghttp2/nghttp2.git nghttp2
 
 # Build and install yaml-cpp into a local install directory
 YAMLCPP_SRC="$LIBS_DIR/yaml-cpp"
@@ -31,12 +32,25 @@ if [ ! -f "$YAMLCPP_INSTALL/lib/libyaml-cpp.a" ]; then
     cmake --install "$YAMLCPP_SRC/build"
 fi
 
+# Build and install nghttp2 into a local install directory
+NGHTTP2_SRC="$LIBS_DIR/nghttp2"
+NGHTTP2_INSTALL="$NGHTTP2_SRC/nghttp2_install"
+if [ ! -f "$NGHTTP2_INSTALL/lib/libnghttp2.a" ]; then
+    cmake -S "$NGHTTP2_SRC" -B "$NGHTTP2_SRC/build" -DBUILD_SHARED_LIBS=OFF \
+        -DENABLE_EXAMPLES=OFF -DENABLE_HPACK_TOOLS=OFF -DENABLE_ASIO_LIB=OFF \
+        -DCMAKE_INSTALL_PREFIX="$NGHTTP2_INSTALL"
+    cmake --build "$NGHTTP2_SRC/build" --config Release
+    cmake --install "$NGHTTP2_SRC/build"
+fi
+
 # Build and install curl into a local install directory
 CURL_SRC="$LIBS_DIR/curl"
 CURL_INSTALL="$CURL_SRC/curl_install"
 if [ ! -f "$CURL_INSTALL/lib/libcurl.a" ]; then
     cmake -S "$CURL_SRC" -B "$CURL_SRC/build" -DBUILD_SHARED_LIBS=OFF -DBUILD_CURL_EXE=OFF \
-        -DCMAKE_INSTALL_PREFIX="$CURL_INSTALL"
+        -DCMAKE_INSTALL_PREFIX="$CURL_INSTALL" \
+        -DNGHTTP2_INCLUDE_DIR="$NGHTTP2_INSTALL/include" \
+        -DNGHTTP2_LIBRARY="$NGHTTP2_INSTALL/lib/libnghttp2.a"
     cmake --build "$CURL_SRC/build" --config Release
     cmake --install "$CURL_SRC/build"
 fi


### PR DESCRIPTION
## Summary
- clone and build nghttp2 in library update scripts
- link nghttp2 in Linux, macOS, and Windows compile scripts
- mention nghttp2 in libs documentation

## Testing
- `./scripts/build_linux.sh` *(fails: Could not find a package configuration file provided by "spdlog")*
- `shfmt -w scripts/update_libs.sh scripts/compile_linux.sh scripts/compile_mac.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b4ad384bc8325b3e828712305b580