### PR TITLE
fix: expose local libs to build tools

### DIFF
--- a/scripts/update_libs.bat
+++ b/scripts/update_libs.bat
@@ -148,7 +148,11 @@ set "PDC_INSTALL=!PDC_SRC!\pdcurses_install"
 )
 
 
-endlocal
+rem Make locally installed libraries discoverable for subsequent builds
+set "PKG_CONFIG_PATH=!YAMLCPP_INSTALL!\lib\pkgconfig;!NGHTTP2_INSTALL!\lib\pkgconfig;!CURL_INSTALL!\lib\pkgconfig;!PDC_INSTALL!\lib\pkgconfig;%PKG_CONFIG_PATH%"
+set "CMAKE_PREFIX_PATH=!YAMLCPP_INSTALL!;!NGHTTP2_INSTALL!;!CURL_INSTALL!;!PDC_INSTALL!;%CMAKE_PREFIX_PATH%"
+
+endlocal & set "PKG_CONFIG_PATH=%PKG_CONFIG_PATH%" & set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%"
 exit /b 0
 
 :clone_or_update

--- a/scripts/update_libs.sh
+++ b/scripts/update_libs.sh
@@ -155,6 +155,10 @@ if [ ! -f "$NGTCP2_INSTALL/lib/libngtcp2.a" ]; then
     cmake --install "$NGTCP2_SRC/build"
 fi
 
+# Make locally installed libraries discoverable for subsequent builds
+export PKG_CONFIG_PATH="$ZLIB_INSTALL/lib/pkgconfig:$BROTLI_INSTALL/lib/pkgconfig:$CARES_INSTALL/lib/pkgconfig:$LIBEV_INSTALL/lib/pkgconfig:$JANSSON_INSTALL/lib/pkgconfig:$SYSTEMD_INSTALL/lib/pkgconfig:$LIBEVENT_INSTALL/lib/pkgconfig:$LIBXML2_INSTALL/lib/pkgconfig:$JEMALLOC_INSTALL/lib/pkgconfig:$NGHTTP3_INSTALL/lib/pkgconfig:$NGTCP2_INSTALL/lib/pkgconfig:${PKG_CONFIG_PATH}"
+export CMAKE_PREFIX_PATH="$OPENSSL_INSTALL;$ZLIB_INSTALL;$BROTLI_INSTALL;$CARES_INSTALL;$LIBEV_INSTALL;$JANSSON_INSTALL;$SYSTEMD_INSTALL;$LIBEVENT_INSTALL;$LIBXML2_INSTALL;$JEMALLOC_INSTALL;$NGHTTP3_INSTALL;$NGTCP2_INSTALL;$CMAKE_PREFIX_PATH"
+
 # Build and install nghttp2 into a local install directory
 NGHTTP2_SRC="$LIBS_DIR/nghttp2"
 NGHTTP2_INSTALL="$NGHTTP2_SRC/nghttp2_install"


### PR DESCRIPTION
## Summary
- ensure scripts/update_libs.sh exposes locally installed libraries via PKG_CONFIG_PATH and CMAKE_PREFIX_PATH so later builds can detect dependencies
- mirror PKG_CONFIG_PATH and CMAKE_PREFIX_PATH setup for Windows in scripts/update_libs.bat

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog")*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `cd build && ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5b1aab5c83259fb7b6af9c917212