### PR TITLE
build: integrate cross-platform dependency fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 ./scripts/build_win.bat
 ```
 
+The Windows install script bootstraps [vcpkg](https://github.com/microsoft/vcpkg) and
+installs the required dependencies (`libev`, `c-ares`, `zlib`, `brotli`, `openssl`,
+`ngtcp2`, `nghttp3`, `jansson`, `libevent`, `libxml2`, `jemalloc`).
+`build_win.bat` configures CMake with the vcpkg toolchain and disables systemd,
+which is not available on Windows.
+
 ## Compiling with g++
 
 On systems with g++ available, you can build the project without CMake using the

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -4,6 +4,12 @@ set "BUILD_DIR=build"
 if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
 cd /d "%BUILD_DIR%"
 
+if "%VCPKG_ROOT%"=="" (
+    echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
+    exit /b 1
+)
+set "VCPKG_TOOLCHAIN=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
+
 where nmake >nul 2>&1
 if %errorlevel%==0 (
     set "GEN=NMake Makefiles"
@@ -25,7 +31,7 @@ if %errorlevel%==0 (
     )
 )
 
-cmake .. -G "%GEN%" -DBUILD_SHARED_LIBS=OFF || exit /b 1
+cmake .. -G "%GEN%" -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE="%VCPKG_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=x64-windows -DENABLE_SYSTEMD=OFF || exit /b 1
 %BUILD_CMD% || exit /b 1
 ctest || exit /b 1
 endlocal

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -2,4 +2,8 @@
 set -e
 # Install packages required for building agpm including ncurses for the TUI
 sudo apt-get update
-sudo apt-get install -y build-essential cmake git libcurl4-openssl-dev libpsl-dev libsqlite3-dev libspdlog-dev libncurses-dev
+sudo apt-get install -y build-essential cmake git \
+    libcurl4-openssl-dev libpsl-dev libsqlite3-dev libspdlog-dev libncurses-dev \
+    libev-dev libc-ares-dev zlib1g-dev libbrotli-dev libssl-dev \
+    libngtcp2-dev libnghttp3-dev libsystemd-dev libjansson-dev \
+    libevent-dev libxml2-dev libjemalloc-dev

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -1,2 +1,14 @@
 @echo off
+setlocal
+
 choco install cmake git curl sqlite spdlog mingw -y
+
+if "%VCPKG_ROOT%"=="" (
+    git clone https://github.com/microsoft/vcpkg "%~dp0..\vcpkg" || exit /b 1
+    set "VCPKG_ROOT=%~dp0..\vcpkg"
+    call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" || exit /b 1
+)
+
+"%VCPKG_ROOT%\vcpkg.exe" install libev c-ares zlib brotli openssl ngtcp2 nghttp3 jansson libevent libxml2 jemalloc || exit /b 1
+
+endlocal


### PR DESCRIPTION
## Summary
- extend Linux install script with required development packages
- bootstrap vcpkg on Windows and install dependencies
- configure Windows build script to use vcpkg toolchain and disable systemd
- document Windows vcpkg setup in README

## Testing
- `./scripts/build_linux.sh`

------
https://chatgpt.com/codex/tasks/task_e_689b64878f888325babdbe4483875f92