### PR TITLE
build(windows): update vcpkg setup and cmake usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 
 The Windows install script bootstraps [vcpkg](https://github.com/microsoft/vcpkg) and
 installs the required dependencies (`libev`, `c-ares`, `zlib`, `brotli`, `openssl`,
-`ngtcp2`, `nghttp3`, `jansson`, `libevent`, `libxml2`, `jemalloc`).
-`build_win.bat` configures CMake with the vcpkg toolchain and disables systemd,
-which is not available on Windows.
+`ngtcp2`, `nghttp3`, `jansson`, `libevent`, `libxml2`, `jemalloc`,
+`nghttp2[openssl,libevent,tools,http3]`).
+`build_win.bat` invokes
+`cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake`
+followed by `cmake --build build --config Release` to compile the project without
+systemd, which is not available on Windows.
 
 ## Compiling with g++
 

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -1,37 +1,14 @@
 @echo off
 setlocal
-set "BUILD_DIR=build"
-if not exist "%BUILD_DIR%" mkdir "%BUILD_DIR%"
-cd /d "%BUILD_DIR%"
 
 if "%VCPKG_ROOT%"=="" (
     echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
     exit /b 1
 )
-set "VCPKG_TOOLCHAIN=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
 
-where nmake >nul 2>&1
-if %errorlevel%==0 (
-    set "GEN=NMake Makefiles"
-    set "BUILD_CMD=cmake --build . -- /M"
-) else (
-    where mingw32-make >nul 2>&1
-    if %errorlevel%==0 (
-        set "GEN=MinGW Makefiles"
-        set "BUILD_CMD=cmake --build ."
-    ) else (
-        where cmake >nul 2>&1
-        if %errorlevel%==0 (
-            set "GEN=Unix Makefiles"
-            set "BUILD_CMD=make --build ../"
-        ) else (
-            echo [ERROR] No suitable build tool found. Install nmake, mingw32-make or make.
-            exit /b 1
-        )
-    )
-)
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows -DBUILD_SHARED_LIBS=OFF -DENABLE_SYSTEMD=OFF || exit /b 1
+cmake --build build --config Release || exit /b 1
+ctest --test-dir build -C Release || exit /b 1
 
-cmake .. -G "%GEN%" -DBUILD_SHARED_LIBS=OFF -DCMAKE_TOOLCHAIN_FILE="%VCPKG_TOOLCHAIN%" -DVCPKG_TARGET_TRIPLET=x64-windows -DENABLE_SYSTEMD=OFF || exit /b 1
-%BUILD_CMD% || exit /b 1
-ctest || exit /b 1
 endlocal
+

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -6,9 +6,12 @@ choco install cmake git curl sqlite mingw -y
 if "%VCPKG_ROOT%"=="" (
     git clone https://github.com/microsoft/vcpkg "%~dp0..\vcpkg" || exit /b 1
     set "VCPKG_ROOT=%~dp0..\vcpkg"
+)
+
+if not exist "%VCPKG_ROOT%\vcpkg.exe" (
     call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" || exit /b 1
 )
 
-"%VCPKG_ROOT%\vcpkg.exe" install libev c-ares zlib brotli openssl ngtcp2 nghttp3 jansson libevent libxml2 jemalloc || exit /b 1
+"%VCPKG_ROOT%\vcpkg.exe" install libev c-ares zlib brotli openssl ngtcp2 nghttp3 jansson libevent libxml2 jemalloc nghttp2[openssl,libevent,tools,http3] --triplet x64-windows || exit /b 1
 
 endlocal


### PR DESCRIPTION
## Summary
- bootstrap vcpkg when missing and install nghttp2 with HTTP/3 support on Windows
- simplify Windows build script to invoke cmake using vcpkg toolchain
- document Windows dependency installation and cmake commands in README

## Testing
- `cmake -S . -B build` *(fails: Could not find package spdlog)*

------
https://chatgpt.com/codex/tasks/task_e_689b868d23b88325afd034bce2a7f86a