### PR TITLE
chore: add vcpkg manifest

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,14 @@
+{
+  "name": "autogithubpullmerge",
+  "version-string": "0.1.0",
+  "dependencies": [
+    "fmt",
+    "spdlog",
+    "yaml-cpp",
+    "nlohmann-json",
+    "curl",
+    "cli11",
+    "sqlite3",
+    "ncurses"
+  ]
+}


### PR DESCRIPTION
## Summary
- add vcpkg.json manifest listing project dependencies

## Testing
- `cmake -B build` *(fails: missing spdlog)*

------
https://chatgpt.com/codex/tasks/task_e_689b8e6eee1483259a59448896e3acbb