### PR TITLE
fix: persist vcpkg path in Windows installer

### DIFF
--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -1,5 +1,4 @@
 @echo off
-setlocal
 
 choco install cmake git curl sqlite mingw -y
 
@@ -14,4 +13,6 @@ if not exist "%VCPKG_ROOT%\vcpkg.exe" (
 
 "%VCPKG_ROOT%\vcpkg.exe" install libev c-ares zlib brotli openssl ngtcp2 nghttp3 jansson libevent libxml2 jemalloc nghttp2[openssl,libevent,tools,http3] --triplet x64-windows || exit /b 1
 
-endlocal
+setx VCPKG_ROOT "%VCPKG_ROOT%" /M
+setx PATH "%PATH%;%VCPKG_ROOT%" /M
+echo Environment variables updated. Please restart your shell for changes to take effect.


### PR DESCRIPTION
## Summary
- persist VCPKG_ROOT using setx
- add VCPKG_ROOT to system PATH
- advise user to restart shell

## Testing
- `./scripts/build_linux.sh` *(fails: Could not find package configuration file provided by "spdlog")*


------
https://chatgpt.com/codex/tasks/task_e_689b8e63ab3c83259c66dfc4a1f871f9