### PR TITLE
build: add vcpkg CMake preset and update docs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,31 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 22,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "vcpkg",
+      "displayName": "vcpkg",
+      "description": "Configure with vcpkg toolchain",
+      "binaryDir": "${sourceDir}/build/vcpkg",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "vcpkg",
+      "configurePreset": "vcpkg"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "vcpkg",
+      "configurePreset": "vcpkg"
+    }
+  ]
+}

--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -1,0 +1,13 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "vcpkg-user",
+      "inherits": "vcpkg",
+      "description": "User preset defining VCPKG_ROOT",
+      "environment": {
+        "VCPKG_ROOT": "/path/to/vcpkg"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -21,31 +21,33 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 ```bash
 ./scripts/install_linux.sh
 ./scripts/update_libs.sh
-./scripts/build_linux.sh
+cmake --preset vcpkg
+cmake --build --preset vcpkg
 ```
 
 ## Building (macOS)
 ```bash
 ./scripts/install_mac.sh
 ./scripts/update_libs.sh
-./scripts/build_mac.sh
+cmake --preset vcpkg
+cmake --build --preset vcpkg
 ```
 
 ## Building (Windows)
 ```powershell
 ./scripts/install_win.bat
 ./scripts/update_libs.bat
-./scripts/build_win.bat
+cmake --preset vcpkg
+cmake --build --preset vcpkg --config Release
 ```
 
 The Windows install script bootstraps [vcpkg](https://github.com/microsoft/vcpkg) and
 installs the required dependencies (`libev`, `c-ares`, `zlib`, `brotli`, `openssl`,
 `ngtcp2`, `nghttp3`, `jansson`, `libevent`, `libxml2`, `jemalloc`,
 `nghttp2[openssl,libevent,tools,http3]`).
-`build_win.bat` invokes
-`cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake`
-followed by `cmake --build build --config Release` to compile the project without
-systemd, which is not available on Windows.
+The `vcpkg` preset sets the `CMAKE_TOOLCHAIN_FILE` automatically so the build
+uses the vcpkg toolchain without requiring manual paths. Edit
+`CMakeUserPresets.json` to set `VCPKG_ROOT` via the `vcpkg-user` preset.
 
 ## Compiling with g++
 

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -66,24 +66,23 @@ press before exiting.
 
 ## Building
 
-Run the appropriate install, update and build scripts for your platform:
+Run the appropriate install and update scripts for your platform, then build
+with the `vcpkg` CMake preset:
 
 ```bash
 ./scripts/install_linux.sh   # Linux
-./scripts/update_libs.sh
-./scripts/build_linux.sh
-```
-
-```bash
 ./scripts/install_mac.sh     # macOS
 ./scripts/update_libs.sh
-./scripts/build_mac.sh
+cmake --preset vcpkg
+cmake --build --preset vcpkg
 ```
 
 ```powershell
 ./scripts/install_win.bat    # Windows
 ./scripts/update_libs.bat
-./scripts/build_win.bat
+cmake --preset vcpkg
+cmake --build --preset vcpkg --config Release
 ```
 
-Alternatively use the `compile_*` scripts for a g++ build without CMake.
+Edit `CMakeUserPresets.json` to provide `VCPKG_ROOT` via the `vcpkg-user`
+preset. Alternatively use the `compile_*` scripts for a g++ build without CMake.


### PR DESCRIPTION
## Summary
- add `vcpkg` CMake preset with toolchain support
- add user preset to define `VCPKG_ROOT`
- document building via `cmake --preset vcpkg`

## Testing
- `VCPKG_ROOT=/path/to/vcpkg cmake --preset vcpkg` *(fails: Could not find package spdlog)*
- `cmake --build --preset vcpkg` *(fails: No rule to make target 'Makefile')*
- `ctest --preset vcpkg`

------
https://chatgpt.com/codex/tasks/task_e_689b927f2c1483258de847d5d4b440cb