### PR TITLE
build: add cross-platform makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+OS := $(shell uname 2>/dev/null || echo Windows_NT)
+
+ifeq ($(OS),Windows_NT)
+    SHELL := cmd.exe
+    .SHELLFLAGS := /C
+    UPDATE_DEPS := scripts\\update_libs.bat
+    BUILD_SCRIPT := scripts\\build_win.bat
+    INSTALL_SCRIPT := scripts\\install_win.bat
+else ifeq ($(OS),Darwin)
+    UPDATE_DEPS := bash scripts/update_libs.sh
+    BUILD_SCRIPT := bash scripts/build_mac.sh
+    INSTALL_SCRIPT := bash scripts/install_mac.sh
+else
+    UPDATE_DEPS := bash scripts/update_libs.sh
+    BUILD_SCRIPT := bash scripts/build_linux.sh
+    INSTALL_SCRIPT := bash scripts/install_linux.sh
+endif
+
+.PHONY: all update-deps build install
+
+all: build
+
+update-deps:
+	$(UPDATE_DEPS)
+
+build:
+	$(BUILD_SCRIPT)
+
+install:
+	$(INSTALL_SCRIPT)


### PR DESCRIPTION
## Summary
- add a simple cross-platform Makefile wrapping existing build, install and dependency scripts

## Testing
- `cmake -S . -B build` *(fails: Could not find package configuration file provided by spdlog)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*
- `ctest --test-dir build` *(no tests were found)*
- `make -n update-deps`
- `make -n build`
- `make -n install`


------
https://chatgpt.com/codex/tasks/task_e_689b955d29548325a52eff6906cd7882