### PR TITLE
fix: guard pdcurses static build

### DIFF
--- a/scripts/update_libs.bat
+++ b/scripts/update_libs.bat
@@ -111,12 +111,13 @@ if not exist "!SQLITE_DIR!" mkdir "!SQLITE_DIR!"
 echo Got sqlite amalgamation.
 
 echo.
-echo 
+echo Build and install pdcurses
 
 rem Build and install pdcurses static library
 set "PDC_SRC=!LIBS_DIR!\pdcurses"
 set "PDC_INSTALL=!PDC_SRC!\pdcurses_install"
 
+if not exist "!PDC_INSTALL!\lib\pdcurses.a" if not exist "!PDC_INSTALL!\lib\pdcurses.lib" (
     where mingw32-make >nul 2>&1
     if not errorlevel 1 (
         rem use mingw32-make if available


### PR DESCRIPTION
## Summary
- avoid rebuilding pdcurses when static library already exists
- emit a helpful message when building pdcurses

## Testing
- `cmake .. && cmake --build . && ctest` *(fails: Could not find a package configuration file provided by "spdlog" with any of the following names: spdlogConfig.cmake, spdlog-config.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689b9ae4c8048325a15e1a34551e203f