### PR TITLE
fix: handle pdcurses update without build tools

### DIFF
--- a/libs/README.md
+++ b/libs/README.md
@@ -1,7 +1,7 @@
 This directory holds third-party dependencies used by autogithubpullmerge.
 Run `./scripts/update_libs.sh` or `./scripts/update_libs.bat` to clone or update
 third-party projects such as **CLI11**, **yaml-cpp**, **libyaml**, **nlohmann/json**,
-**spdlog**, **curl**, **nghttp2**, **sqlite**, **ncurses**, **libev**, **c-ares**,
+**spdlog**, **curl**, **nghttp2**, **sqlite**, **pdcurses**, **libev**, **c-ares**,
 **zlib**, **brotli**, **openssl**, **ngtcp2**, **nghttp3**, **systemd**,
 **jansson**, **libevent**, **libxml2** and **jemalloc**. After cloning, the SQLite
 repository's `VERSION` file is renamed to `VERSION.txt` to prevent conflicts


### PR DESCRIPTION
## Summary
- add fallback to download prebuilt PDCurses if no make tools are present
- copy panel header alongside curses.h during PDCurses install
- document PDCurses in libs README

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "spdlog")*

------
https://chatgpt.com/codex/tasks/task_e_689b9c529c3c8325b6a1fd6ce522f667