### PR TITLE
fix: handle existing vcpkg dir in Windows installer

### DIFF
--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -3,8 +3,15 @@
 choco install cmake git curl sqlite mingw -y
 
 if "%VCPKG_ROOT%"=="" (
-    git clone https://github.com/microsoft/vcpkg "%~dp0..\vcpkg" || exit /b 1
     set "VCPKG_ROOT=%~dp0..\vcpkg"
+)
+
+if not exist "%VCPKG_ROOT%\.vcpkg-root" (
+    if exist "%VCPKG_ROOT%" (
+        echo Existing vcpkg directory found but it is not a valid vcpkg repository. Removing...
+        rmdir /s /q "%VCPKG_ROOT%" || exit /b 1
+    )
+    git clone https://github.com/microsoft/vcpkg "%VCPKG_ROOT%" || exit /b 1
 )
 
 if not exist "%VCPKG_ROOT%\vcpkg.exe" (


### PR DESCRIPTION
## Summary
- avoid git clone failure when vcpkg directory exists by removing invalid vcpkg folder
- set VCPKG_ROOT before checking repository

## Testing
- `bash scripts/build_linux.sh` *(fails: Could not find toolchain file: /workspace/autogithubpullmerge/vcpkg/scripts/buildsystems/vcpkg.cmake)*

------
https://chatgpt.com/codex/tasks/task_e_689bae67b284832585548c2919da6806