### PR TITLE
build(win): auto-detect VCPKG_ROOT

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -2,8 +2,13 @@
 setlocal
 
 if "%VCPKG_ROOT%"=="" (
-    echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
-    exit /b 1
+    set "SCRIPT_DIR=%~dp0"
+    if exist "%SCRIPT_DIR%..\vcpkg\vcpkg.exe" (
+        set "VCPKG_ROOT=%SCRIPT_DIR%..\vcpkg"
+    ) else (
+        echo [ERROR] VCPKG_ROOT not set and vcpkg not found. Run scripts\install_win.bat first.
+        exit /b 1
+    )
 )
 
 cmake --preset vcpkg || exit /b 1


### PR DESCRIPTION
## Summary
- detect vcpkg installation automatically when `VCPKG_ROOT` is unset
- guide users to run `scripts/install_win.bat` when vcpkg is missing

## Testing
- `make build` *(fails: Could not find toolchain file)*
- `make lint` *(fails: No rule to make target 'lint')*

------
https://chatgpt.com/codex/tasks/task_e_689baea1b10483259d1db219c0c66b1c