### PR TITLE
build: bootstrap vcpkg for tests and CI

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,6 +1,26 @@
 #!/usr/bin/env bash
 set -e
 
+if command -v apt-get >/dev/null 2>&1; then
+	apt-get update
+	apt-get install -y --no-install-recommends linux-libc-dev
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ -z "${VCPKG_ROOT}" ]]; then
+	if [[ ! -d "${SCRIPT_DIR}/../vcpkg" ]]; then
+		git clone https://github.com/microsoft/vcpkg "${SCRIPT_DIR}/../vcpkg"
+	fi
+	export VCPKG_ROOT="${SCRIPT_DIR}/../vcpkg"
+fi
+
+if [[ ! -f "${VCPKG_ROOT}/vcpkg" ]]; then
+	"${VCPKG_ROOT}/bootstrap-vcpkg.sh"
+fi
+
+"${VCPKG_ROOT}/vcpkg" install
+
 cmake --preset vcpkg
 cmake --build --preset vcpkg
 ctest --preset vcpkg

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+if [[ -z "${VCPKG_ROOT}" ]]; then
+	if [[ ! -d "${SCRIPT_DIR}/../vcpkg" ]]; then
+		git clone https://github.com/microsoft/vcpkg "${SCRIPT_DIR}/../vcpkg"
+	fi
+	export VCPKG_ROOT="${SCRIPT_DIR}/../vcpkg"
+fi
+
+if [[ ! -f "${VCPKG_ROOT}/vcpkg" ]]; then
+	"${VCPKG_ROOT}/bootstrap-vcpkg.sh"
+fi
+
+"${VCPKG_ROOT}/vcpkg" install
+
 cmake --preset vcpkg
 cmake --build --preset vcpkg
 ctest --preset vcpkg

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -2,9 +2,17 @@
 setlocal
 
 if "%VCPKG_ROOT%"=="" (
-    echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
-    exit /b 1
+    if not exist "%~dp0..\vcpkg\.git" (
+        git clone https://github.com/microsoft/vcpkg "%~dp0..\vcpkg" || exit /b 1
+    )
+    set "VCPKG_ROOT=%~dp0..\vcpkg"
 )
+
+if not exist "%VCPKG_ROOT%\vcpkg.exe" (
+    call "%VCPKG_ROOT%\bootstrap-vcpkg.bat" || exit /b 1
+)
+
+"%VCPKG_ROOT%\vcpkg.exe" install || exit /b 1
 
 cmake --preset vcpkg || exit /b 1
 cmake --build --preset vcpkg --config Release || exit /b 1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,78 +1,45 @@
-add_executable(test_main test_main.cpp)
+find_package(CLI11 CONFIG REQUIRED)
+find_package(yaml-cpp REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(CURL REQUIRED)
+find_package(SQLite3 REQUIRED)
+find_package(Curses REQUIRED)
+find_package(spdlog REQUIRED)
 
-target_link_libraries(test_main PRIVATE autogithubpullmerge_lib)
-add_test(NAME main_test COMMAND test_main)
+set(AGPM_TEST_LIBS
+    autogithubpullmerge_lib
+    CLI11::CLI11
+    yaml-cpp::yaml-cpp
+    nlohmann_json::nlohmann_json
+    CURL::libcurl
+    SQLite::SQLite3
+    spdlog::spdlog
+    ${CURSES_LIBRARIES})
 
-add_executable(test_cli test_cli.cpp)
-target_link_libraries(test_cli PRIVATE autogithubpullmerge_lib)
-add_test(NAME cli_test COMMAND test_cli)
+function(add_agpm_test target)
+  add_executable(${target} ${ARGN})
+  target_link_libraries(${target} PRIVATE ${AGPM_TEST_LIBS})
+  string(REGEX REPLACE "^test_" "" base "${target}")
+  add_test(NAME "${base}_test" COMMAND ${target})
+endfunction()
 
-add_executable(test_config test_config.cpp)
-target_link_libraries(test_config PRIVATE autogithubpullmerge_lib)
-add_test(NAME config_test COMMAND test_config)
-
-add_executable(test_config_manager test_config_manager.cpp)
-target_link_libraries(test_config_manager PRIVATE autogithubpullmerge_lib)
-add_test(NAME config_manager_test COMMAND test_config_manager)
-
-add_executable(test_github_client test_github_client.cpp)
-target_link_libraries(test_github_client PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_client_test COMMAND test_github_client)
-
-add_executable(test_github_client_behavior test_github_client_behavior.cpp)
-target_link_libraries(test_github_client_behavior PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_client_behavior_test COMMAND test_github_client_behavior)
-
-add_executable(test_history test_history.cpp)
-target_link_libraries(test_history PRIVATE autogithubpullmerge_lib)
-add_test(NAME history_test COMMAND test_history)
-
-add_executable(test_tui test_tui.cpp)
-target_link_libraries(test_tui PRIVATE autogithubpullmerge_lib)
-add_test(NAME tui_test COMMAND test_tui)
-
-add_executable(test_github_filter test_github_filter.cpp)
-target_link_libraries(test_github_filter PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_filter_test COMMAND test_github_filter)
-
-add_executable(test_poller test_poller.cpp)
-target_link_libraries(test_poller PRIVATE autogithubpullmerge_lib)
-add_test(NAME poller_test COMMAND test_poller)
-
-add_executable(test_pr_since test_pr_since.cpp)
-target_link_libraries(test_pr_since PRIVATE autogithubpullmerge_lib)
-add_test(NAME pr_since_test COMMAND test_pr_since)
-
-add_executable(test_cli_tokens test_cli_tokens.cpp)
-target_link_libraries(test_cli_tokens PRIVATE autogithubpullmerge_lib)
-add_test(NAME cli_tokens_test COMMAND test_cli_tokens)
-
-add_executable(test_config_loading test_config_loading.cpp)
-target_link_libraries(test_config_loading PRIVATE autogithubpullmerge_lib)
-add_test(NAME config_loading_test COMMAND test_config_loading)
-
-add_executable(test_github_client_headers test_github_client_headers.cpp)
-target_link_libraries(test_github_client_headers PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_client_headers_test COMMAND test_github_client_headers)
-add_executable(test_github_client_delay test_github_client_delay.cpp)
-target_link_libraries(test_github_client_delay PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_client_delay_test COMMAND test_github_client_delay)
-
-add_executable(test_github_client_accept test_github_client_accept.cpp)
-target_link_libraries(test_github_client_accept PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_client_accept_test COMMAND test_github_client_accept)
-add_executable(test_history_merge test_history_merge.cpp)
-target_link_libraries(test_history_merge PRIVATE autogithubpullmerge_lib)
-add_test(NAME history_merge_test COMMAND test_history_merge)
-
-add_executable(test_github_poller test_github_poller.cpp)
-target_link_libraries(test_github_poller PRIVATE autogithubpullmerge_lib)
-add_test(NAME github_poller_test COMMAND test_github_poller)
-
-add_executable(test_branch_cleanup test_branch_cleanup.cpp)
-target_link_libraries(test_branch_cleanup PRIVATE autogithubpullmerge_lib)
-add_test(NAME branch_cleanup_test COMMAND test_branch_cleanup)
-
-add_executable(test_auto_merge test_auto_merge.cpp)
-target_link_libraries(test_auto_merge PRIVATE autogithubpullmerge_lib)
-add_test(NAME auto_merge_test COMMAND test_auto_merge)
+add_agpm_test(test_main test_main.cpp)
+add_agpm_test(test_cli test_cli.cpp)
+add_agpm_test(test_config test_config.cpp)
+add_agpm_test(test_config_manager test_config_manager.cpp)
+add_agpm_test(test_github_client test_github_client.cpp)
+add_agpm_test(test_github_client_behavior test_github_client_behavior.cpp)
+add_agpm_test(test_history test_history.cpp)
+add_agpm_test(test_tui test_tui.cpp)
+add_agpm_test(test_github_filter test_github_filter.cpp)
+add_agpm_test(test_poller test_poller.cpp)
+add_agpm_test(test_pr_since test_pr_since.cpp)
+add_agpm_test(test_cli_tokens test_cli_tokens.cpp)
+add_agpm_test(test_config_loading test_config_loading.cpp)
+add_agpm_test(test_github_client_headers test_github_client_headers.cpp)
+add_agpm_test(test_github_client_delay test_github_client_delay.cpp)
+add_agpm_test(test_github_client_accept test_github_client_accept.cpp)
+add_agpm_test(test_history_merge test_history_merge.cpp)
+add_agpm_test(test_github_poller test_github_poller.cpp)
+add_agpm_test(test_branch_cleanup test_branch_cleanup.cpp)
+add_agpm_test(test_auto_merge test_auto_merge.cpp)


### PR DESCRIPTION
## Summary
- find packages for test targets through vcpkg
- bootstrap vcpkg in build scripts before running tests
- install linux headers in build script to satisfy OpenSSL dependency

## Testing
- `shellcheck scripts/build_linux.sh scripts/build_mac.sh`
- `shfmt -w scripts/build_linux.sh scripts/build_mac.sh`
- `cmake-format -i tests/CMakeLists.txt`
- `./scripts/build_linux.sh` *(in-progress build; OpenSSL no longer complains about missing linux-libc-dev)*

------
https://chatgpt.com/codex/tasks/task_e_689bae81f8f483258c9891156442cb66