### PR TITLE
Use fresh builds to avoid preset generator conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,21 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 ## Building (Linux)
 ```bash
 ./scripts/install_linux.sh
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg
 ```
 
 ## Building (macOS)
 ```bash
 ./scripts/install_mac.sh
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg
 ```
 
 ## Building (Windows)
 ```powershell
 ./scripts/install_win.bat
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg --config Release
 ```
 
@@ -90,7 +90,7 @@ echo "export PATH=\"\$VCPKG_ROOT:\$PATH\"" >> ~/.zprofile
 After setting up vcpkg, configure and build with the `vcpkg` CMake preset:
 
 ```bash
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg
 ```
 

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -6,6 +6,6 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
     exit 1
 fi
 
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg
 ctest --preset vcpkg

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -6,6 +6,6 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
     exit 1
 fi
 
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg
 ctest --preset vcpkg

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -11,7 +11,7 @@ if "%VCPKG_ROOT%"=="" (
     )
 )
 
-cmake --preset vcpkg || exit /b 1
+cmake --preset vcpkg --fresh || exit /b 1
 cmake --build --preset vcpkg --config Release || exit /b 1
 ctest --preset vcpkg || exit /b 1
 

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -6,5 +6,5 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
     exit 1
 fi
 
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -6,5 +6,5 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
     exit 1
 fi
 
-cmake --preset vcpkg
+cmake --preset vcpkg --fresh
 cmake --build --preset vcpkg

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -3,5 +3,5 @@ if "%VCPKG_ROOT%"=="" (
     echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
     exit /b 1
 )
-cmake --preset vcpkg || exit /b 1
+cmake --preset vcpkg --fresh || exit /b 1
 cmake --build --preset vcpkg --config Release || exit /b 1


### PR DESCRIPTION
## Summary
- ensure CMake presets always start from a clean cache by adding `--fresh`
- document `--fresh` flag in README to avoid generator mismatches

## Testing
- `VCPKG_ROOT=/tmp ./scripts/build_linux.sh` *(fails: Could not find toolchain file)*

------
https://chatgpt.com/codex/tasks/task_e_689bbc1c3f00832586aea4772cd59556