### PR TITLE
fix: improve Windows vcpkg setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.16)
 
-# Detect vcpkg toolchain on Windows if not provided
-if(WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+# Detect vcpkg toolchain if not provided
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   if(DEFINED ENV{VCPKG_ROOT})
     set(CMAKE_TOOLCHAIN_FILE
         "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,10 +11,7 @@
       "displayName": "vcpkg",
       "description": "Configure with vcpkg toolchain",
       "generator": "Ninja",
-      "binaryDir": "${sourceDir}/build/vcpkg",
-      "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
-      }
+      "binaryDir": "${sourceDir}/build/vcpkg"
     }
   ],
   "buildPresets": [

--- a/README.md
+++ b/README.md
@@ -41,10 +41,11 @@ cmake --build --preset vcpkg --config Release
 
 The install scripts clone and bootstrap [vcpkg](https://github.com/microsoft/vcpkg)
 if `VCPKG_ROOT` is not set, then install all dependencies declared in
-`vcpkg.json`. The `vcpkg` CMake preset uses `VCPKG_ROOT` to locate the toolchain,
-so builds run without extra flags. To use a
-different vcpkg installation, create or edit `CMakeUserPresets.json` or export
-`VCPKG_ROOT` and add it to your `PATH`.
+`vcpkg.json`. They also install the Ninja build tool on Windows so the preset
+works out of the box. The `vcpkg` CMake preset automatically locates the
+toolchain via `VCPKG_ROOT` or a local `vcpkg` directory, so builds run without
+extra flags. To use a different vcpkg installation, create or edit
+`CMakeUserPresets.json` or export `VCPKG_ROOT` and add it to your `PATH`.
 ## Compiling with g++
 
 The `compile_*` scripts wrap the CMake preset for convenience:

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -1,6 +1,6 @@
 @echo off
 
-choco install cmake git curl sqlite mingw -y
+choco install cmake git curl sqlite mingw ninja -y
 
 if "%VCPKG_ROOT%"=="" (
     set "VCPKG_ROOT=%~dp0..\vcpkg"


### PR DESCRIPTION
## Summary
- auto-detect vcpkg toolchain in CMakeLists and simplify preset
- install Ninja on Windows during dependency setup
- document preset auto-detection and Ninja requirement

## Testing
- `cmake --preset vcpkg` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bbd7532708325998972cee90d6adb