### PR TITLE
build: configure mingw triplet on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,12 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   endif()
 endif()
 
+# Use MinGW vcpkg triplet on Windows when none is specified
+if(WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
+  set(VCPKG_TARGET_TRIPLET "x64-mingw-static" CACHE STRING
+                                 "Vcpkg target triplet" FORCE)
+endif()
+
 project(autogithubpullmerge LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - SQLite-based history storage with CSV/JSON export
 - Configurable logging with `--log-level`
 - Uses spdlog for colored console logging
-- Cross-platform compile scripts (g++ on Unix-like systems, MSVC on Windows)
+- Cross-platform compile scripts (g++ on all platforms)
 - CLI options for GitHub API keys (`--api-key`, `--api-key-from-stream`,
   `--api-key-url`, `--api-key-url-user`, `--api-key-url-password`,
   `--api-key-file`)
@@ -34,18 +34,10 @@ cmake --build --preset vcpkg
 
 ## Building (Windows)
 ```bat
-:: Run in an "x64 Native Tools Command Prompt for VS 2022"
 scripts\install_win.bat
-rmdir /s /q build\vcpkg
-cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
-  -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
-  -DVCPKG_TARGET_TRIPLET=x64-windows ^
-  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl
-cmake --build build\vcpkg --config Release
+cmake --preset vcpkg --fresh
+cmake --build --preset vcpkg
 ```
-
-Ensure `cl.exe` appears first in `PATH` and that `C:\Strawberry\c\bin` is not
-earlier in the path to avoid fallback to MinGW.
 
 
 The install scripts clone and bootstrap
@@ -63,7 +55,7 @@ The `compile_*` scripts wrap the platform build commands:
 ```bash
 ./scripts/compile_linux.sh   # Linux (g++)
 ./scripts/compile_mac.sh     # macOS (g++)
-./scripts/compile_win.bat    # Windows (MSVC/CL)
+./scripts/compile_win.bat    # Windows (g++)
 ```
 Run the matching `install_*` script for your platform first to ensure vcpkg is
 bootstrapped and dependencies are installed.
@@ -77,7 +69,7 @@ To install vcpkg manually without the helper scripts:
 git clone https://github.com/microsoft/vcpkg %USERPROFILE%\vcpkg
 %USERPROFILE%\vcpkg\bootstrap-vcpkg.bat
 %USERPROFILE%\vcpkg\vcpkg.exe integrate install
-setx VCPKG_DEFAULT_TRIPLET x64-windows /M
+setx VCPKG_DEFAULT_TRIPLET x64-mingw-static /M
 setx VCPKG_ROOT "%USERPROFILE%\vcpkg" /M
 setx PATH "%PATH%;%VCPKG_ROOT%" /M
 ```

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -12,14 +12,10 @@ if "%VCPKG_ROOT%"=="" (
 )
 
 rmdir /s /q build\vcpkg 2>nul
-echo %PATH% | findstr /I "C:\\Strawberry\\c\\bin" >nul
-if %ERRORLEVEL%==0 (
-    echo [WARNING] C:\Strawberry\c\bin found in PATH. Move it after MSVC tools.
-)
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
-  -DVCPKG_TARGET_TRIPLET=x64-windows ^
-  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+  -DVCPKG_TARGET_TRIPLET=x64-mingw-static ^
+  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ || exit /b 1
 cmake --build build\vcpkg --config Release || exit /b 1
 ctest --test-dir build\vcpkg -C Release || exit /b 1
 

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -4,13 +4,9 @@ if "%VCPKG_ROOT%"=="" (
     exit /b 1
 )
 rmdir /s /q build\vcpkg 2>nul
-echo %PATH% | findstr /I "C:\\Strawberry\\c\\bin" >nul
-if %ERRORLEVEL%==0 (
-    echo [WARNING] C:\Strawberry\c\bin found in PATH. Move it after MSVC tools.
-)
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
-  -DVCPKG_TARGET_TRIPLET=x64-windows ^
-  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+  -DVCPKG_TARGET_TRIPLET=x64-mingw-static ^
+  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ || exit /b 1
 cmake --build build\vcpkg --config Release || exit /b 1
  

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -4,11 +4,11 @@ echo ============================================================
 echo   AutoGitHubPullMerge Windows Dependency Installation
 echo ============================================================
 echo.
-echo This script assumes Visual Studio Build Tools are installed.
-echo Run future builds from an "x64 Native Tools Command Prompt for VS 2022".
+echo Ensure a MinGW toolchain is available in your PATH.
+echo Run future builds from a shell where g++ is accessible.
 echo.
 echo [1/5] Installing required packages...
-choco install cmake git curl sqlite ninja -y
+choco install cmake git curl sqlite ninja mingw -y
 
 echo [2/5] Determining vcpkg location...
 if "%VCPKG_ROOT%"=="" (
@@ -33,7 +33,7 @@ if not exist "%VCPKG_ROOT%\vcpkg.exe" (
 "%VCPKG_ROOT%\vcpkg.exe" integrate install || exit /b 1
 
 echo [5/5] Installing project dependencies...
-if "%VCPKG_DEFAULT_TRIPLET%"=="" set "VCPKG_DEFAULT_TRIPLET=x64-windows"
+if "%VCPKG_DEFAULT_TRIPLET%"=="" set "VCPKG_DEFAULT_TRIPLET=x64-mingw-static"
 "%VCPKG_ROOT%\vcpkg.exe" install --triplet %VCPKG_DEFAULT_TRIPLET% || exit /b 1
 
 echo Persisting environment variables...


### PR DESCRIPTION
## Summary
- default Windows builds to x64-mingw-static for vcpkg
- update Windows scripts to use g++/MinGW
- document new Windows g++ workflow

## Testing
- `cmake --preset vcpkg` *(fails: building vcpkg dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689bd854befc8325a011cb0344abff38