### PR TITLE
docs: add roadmap reference

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,23 @@
+# Roadmap
+
+## Milestones
+
+### Milestone 1: Core Functionality
+- Command line interface with extensive configuration options
+- YAML and JSON configuration file support
+- Comprehensive logging facilities
+
+### Milestone 2: GitHub Integration
+- Efficient polling with rate limiting and multithreaded workers
+- Export pull request data to CSV or JSON
+- SQLite-backed history storage
+
+### Milestone 3: TUI Enhancements
+- Responsive terminal user interface with color and hotkeys
+- Automatic merge and branch cleanup features
+- Rules for protected branches and stray branch handling
+
+## Future Features
+- Sorting and filtering options for repositories and pull requests
+- Network traffic limits and bandwidth controls
+- Additional integrations and automation capabilities

--- a/agents.md
+++ b/agents.md
@@ -1,4 +1,4 @@
-You should always follow the project roadmap and specification at specs.md
+You should always follow the project specification at specs.md and the roadmap at ROADMAP.md
 
 - Ensure that all code is correctly formatted always
 - Ensure it passes lint tests and reformat if needed


### PR DESCRIPTION
## Summary
- add roadmap outlining milestones and features
- update agent instructions to reference roadmap

## Testing
- `make format` *(fails: No rule to make target 'format')*
- `make lint` *(fails: No rule to make target 'lint')*
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_689bdd1c22c083259de681e9fbc08b38