### PR TITLE
build: switch Windows builds to MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
   endif()
 endif()
 
-# Use MinGW vcpkg triplet on Windows when none is specified
+# Use MSVC vcpkg triplet on Windows when none is specified
 if(WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
-  set(VCPKG_TARGET_TRIPLET "x64-mingw-static" CACHE STRING
+  set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING
                                  "Vcpkg target triplet" FORCE)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - SQLite-based history storage with CSV/JSON export
 - Configurable logging with `--log-level`
 - Uses spdlog for colored console logging
-- Cross-platform compile scripts (g++ on all platforms)
+- Cross-platform compile scripts (MSVC on Windows, g++ on Linux/macOS)
 - CLI options for GitHub API keys (`--api-key`, `--api-key-from-stream`,
   `--api-key-url`, `--api-key-url-user`, `--api-key-url-password`,
   `--api-key-file`)
@@ -55,7 +55,7 @@ The `compile_*` scripts wrap the platform build commands:
 ```bash
 ./scripts/compile_linux.sh   # Linux (g++)
 ./scripts/compile_mac.sh     # macOS (g++)
-./scripts/compile_win.bat    # Windows (g++)
+./scripts/compile_win.bat    # Windows (MSVC)
 ```
 Run the matching `install_*` script for your platform first to ensure vcpkg is
 bootstrapped and dependencies are installed.
@@ -69,7 +69,7 @@ To install vcpkg manually without the helper scripts:
 git clone https://github.com/microsoft/vcpkg %USERPROFILE%\vcpkg
 %USERPROFILE%\vcpkg\bootstrap-vcpkg.bat
 %USERPROFILE%\vcpkg\vcpkg.exe integrate install
-setx VCPKG_DEFAULT_TRIPLET x64-mingw-static /M
+setx VCPKG_DEFAULT_TRIPLET x64-windows-static /M
 setx VCPKG_ROOT "%USERPROFILE%\vcpkg" /M
 setx PATH "%PATH%;%VCPKG_ROOT%" /M
 ```

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -14,8 +14,8 @@ if "%VCPKG_ROOT%"=="" (
 rmdir /s /q build\vcpkg 2>nul
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
-  -DVCPKG_TARGET_TRIPLET=x64-mingw-static ^
-  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ || exit /b 1
+  -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
+  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
 cmake --build build\vcpkg --config Release || exit /b 1
 ctest --test-dir build\vcpkg -C Release || exit /b 1
 

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -6,7 +6,7 @@ if "%VCPKG_ROOT%"=="" (
 rmdir /s /q build\vcpkg 2>nul
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
-  -DVCPKG_TARGET_TRIPLET=x64-mingw-static ^
-  -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ || exit /b 1
+  -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
+  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
 cmake --build build\vcpkg --config Release || exit /b 1
  

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -4,11 +4,11 @@ echo ============================================================
 echo   AutoGitHubPullMerge Windows Dependency Installation
 echo ============================================================
 echo.
-echo Ensure a MinGW toolchain is available in your PATH.
-echo Run future builds from a shell where g++ is accessible.
+echo Ensure Microsoft Visual C++ Build Tools are available in your PATH.
+echo Run future builds from a Developer Command Prompt where cl is accessible.
 echo.
 echo [1/5] Installing required packages...
-choco install cmake git curl sqlite ninja mingw -y
+choco install cmake git curl sqlite ninja visualstudio2022buildtools -y
 
 echo [2/5] Determining vcpkg location...
 if "%VCPKG_ROOT%"=="" (
@@ -33,7 +33,7 @@ if not exist "%VCPKG_ROOT%\vcpkg.exe" (
 "%VCPKG_ROOT%\vcpkg.exe" integrate install || exit /b 1
 
 echo [5/5] Installing project dependencies...
-if "%VCPKG_DEFAULT_TRIPLET%"=="" set "VCPKG_DEFAULT_TRIPLET=x64-mingw-static"
+if "%VCPKG_DEFAULT_TRIPLET%"=="" set "VCPKG_DEFAULT_TRIPLET=x64-windows-static"
 "%VCPKG_ROOT%\vcpkg.exe" install --triplet %VCPKG_DEFAULT_TRIPLET% || exit /b 1
 
 echo Persisting environment variables...

--- a/specs.md
+++ b/specs.md
@@ -35,6 +35,6 @@ Product specification list
 - has cli arg to include repo, its repeatable
 - by default checks for all repos available to a given api key
 - has cli mode to use global mode or individual repo/multiple repo mode
-- compilation uses g++ in all platforms
+- compilation uses g++ on Linux and macOS, and MSVC on Windows
 - use the latest c++
 - ensure compilation uses good optimizations


### PR DESCRIPTION
## Summary
- default to MSVC vcpkg triplet on Windows builds
- update Windows scripts to use `cl` and install Visual Studio Build Tools
- document MSVC-based workflow across README and specs

## Testing
- `bash scripts/install_linux.sh` *(fails: building libev:x64-linux failed with BUILD_FAILED)*
- `cmake --preset vcpkg --fresh` *(fails: vcpkg install failed, CMAKE_CXX_COMPILER not set)*
- `ctest --test-dir build/vcpkg` *(no tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_689be13e14e883259f63acecbf01e559