### PR TITLE
docs: document stray branch cleanup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ API keys can be provided in several ways:
   (e.g. `30m`, `2h`, `1d`).
 - `--include-merged` lists merged pull requests in addition to open ones (off by default).
 - `--only-poll-prs` polls only pull requests.
-- `--only-poll-stray` polls only stray branches.
-- `--reject-dirty` closes stray branches that have diverged.
+- `--only-poll-stray` enters an isolated stray-branch purge mode.
+- `--reject-dirty` overrides protection and closes stray branches that have
+  diverged.
 - `--purge-prefix` deletes branches with this prefix after their pull
-  request is closed or merged.
+  request is closed or merged, integrating cleanup into the merge workflow.
 - `--auto-merge` merges pull requests automatically.
 
 ## Examples

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -35,6 +35,27 @@ to build the project on supported platforms.
 - `--pr-since` - only list pull requests newer than the given duration
   (e.g. `30m`, `2h`, `1d`).
 
+## Stray Branch Management
+
+### Isolated Stray-Branch Purge Mode
+
+Use `--only-poll-stray` to scan repositories exclusively for stray branches.
+This isolated mode ignores pull requests and focuses solely on purging unused
+branches.
+
+### Integrated Branch Deletion
+
+Supply `--purge-prefix` to remove branches with a matching prefix after their
+pull request has been merged or closed. The cleanup is integrated into the
+normal pull request workflow so branches disappear once they are no longer
+needed.
+
+### Overriding Dirty Branches
+
+Branches that have diverged from their remote are considered dirty and are
+skipped by default. Pass `--reject-dirty` to close these branches
+automatically, overriding the protection for dirty branches.
+
 ## Configuration File Examples
 
 YAML:


### PR DESCRIPTION
## Summary
- describe isolated stray-branch purge mode
- outline integrated branch deletion after merge or close
- document flag to override dirty branches

## Testing
- `bash scripts/install_linux.sh` *(fails: Error code 2 building libev:x64-linux)*
- `cmake --preset vcpkg` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_689be3c89a5c8325958e9a60b59d42ad