### PR TITLE
fix(win): auto-configure MSVC in build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,13 @@ cmake --build --preset vcpkg
 ## Building (Windows)
 ```bat
 scripts\install_win.bat
-cmake --preset vcpkg --fresh
-cmake --build --preset vcpkg
+scripts\build_win.bat
 ```
+
+The build script uses `vswhere` to locate the newest Visual Studio
+installation and calls `VsDevCmd.bat` so `cl.exe` is available. Visual
+Studio Build Tools must be installed but the script can be run from a normal
+command prompt.
 
 
 The install scripts clone and bootstrap
@@ -58,7 +62,8 @@ The `compile_*` scripts wrap the platform build commands:
 ./scripts/compile_win.bat    # Windows (MSVC)
 ```
 Run the matching `install_*` script for your platform first to ensure vcpkg is
-bootstrapped and dependencies are installed.
+bootstrapped and dependencies are installed. The Windows script mirrors the
+logic in `build_win.bat` and automatically configures the MSVC environment.
 
 ## vcpkg Manual Setup
 

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -100,10 +100,11 @@ cmake --build --preset vcpkg
 
 ```powershell
 ./scripts/install_win.bat    # Windows
-cmake --preset vcpkg
-cmake --build --preset vcpkg --config Release
+./scripts/build_win.bat      # uses MSVC
 ```
 
-The default preset uses `VCPKG_ROOT` to locate vcpkg. To use a custom
-installation, create or edit `CMakeUserPresets.json` or export `VCPKG_ROOT` and add it to
+The default preset uses `VCPKG_ROOT` to locate vcpkg. On Windows the build
+script calls `vswhere` and `VsDevCmd.bat` so `cl.exe` is available without
+launching a dedicated developer shell. To use a custom vcpkg installation,
+create or edit `CMakeUserPresets.json` or export `VCPKG_ROOT` and add it to
 your `PATH`.

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -1,6 +1,19 @@
 @echo off
 setlocal
 
+:: Ensure MSVC build tools are available
+where cl >nul 2>&1
+if %errorlevel% neq 0 (
+    for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+        set "VS_PATH=%%i"
+    )
+    if not defined VS_PATH (
+        echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
+        exit /b 1
+    )
+    call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
+)
+
 if "%VCPKG_ROOT%"=="" (
     set "SCRIPT_DIR=%~dp0"
     if exist "%SCRIPT_DIR%..\vcpkg\vcpkg.exe" (

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -1,4 +1,19 @@
 @echo off
+setlocal
+
+:: Ensure MSVC build tools are available
+where cl >nul 2>&1
+if %errorlevel% neq 0 (
+    for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+        set "VS_PATH=%%i"
+    )
+    if not defined VS_PATH (
+        echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
+        exit /b 1
+    )
+    call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
+)
+
 if "%VCPKG_ROOT%"=="" (
     echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
     exit /b 1
@@ -9,4 +24,5 @@ cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
 cmake --build build\vcpkg --config Release || exit /b 1
- 
+
+endlocal

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -4,11 +4,11 @@ echo ============================================================
 echo   AutoGitHubPullMerge Windows Dependency Installation
 echo ============================================================
 echo.
-echo Ensure Microsoft Visual C++ Build Tools are available in your PATH.
-echo Run future builds from a Developer Command Prompt where cl is accessible.
+echo Ensure Microsoft Visual C++ Build Tools are installed.
+echo Build scripts automatically locate MSVC using vswhere.
 echo.
 echo [1/5] Installing required packages...
-choco install cmake git curl sqlite ninja visualstudio2022buildtools -y
+choco install cmake git curl sqlite ninja visualstudio2022buildtools vswhere -y
 
 echo [2/5] Determining vcpkg location...
 if "%VCPKG_ROOT%"=="" (


### PR DESCRIPTION
## Summary
- ensure Windows build scripts detect MSVC with vswhere and bootstrap the Visual Studio environment
- install vswhere on Windows and clarify MSVC setup in documentation

## Testing
- `./scripts/build_linux.sh` *(fails: [ERROR] VCPKG_ROOT not set. Run install_linux.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_689bebf548b48325beed22627c1e1037