### PR TITLE
fix: improve Windows build tools initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ scripts\install_win.bat
 scripts\build_win.bat
 ```
 
-The build script uses `vswhere` to locate the newest Visual Studio
-installation and calls `VsDevCmd.bat` so `cl.exe` is available. Visual
-Studio Build Tools must be installed but the script can be run from a normal
-command prompt.
+The build script automatically locates `vswhere.exe` (falling back to the
+default Visual Studio Installer path when it's not on `PATH`) to find the
+newest Visual Studio installation. It then calls `VsDevCmd.bat` so `cl.exe`
+is available. Visual Studio Build Tools must be installed but the script can
+be run from a normal command prompt.
 
 
 The install scripts clone and bootstrap

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -104,7 +104,8 @@ cmake --build --preset vcpkg
 ```
 
 The default preset uses `VCPKG_ROOT` to locate vcpkg. On Windows the build
-script calls `vswhere` and `VsDevCmd.bat` so `cl.exe` is available without
-launching a dedicated developer shell. To use a custom vcpkg installation,
-create or edit `CMakeUserPresets.json` or export `VCPKG_ROOT` and add it to
-your `PATH`.
+script locates `vswhere.exe` (falling back to the standard Visual Studio
+Installer directory if needed) and invokes `VsDevCmd.bat` so `cl.exe` is
+available without launching a dedicated developer shell. To use a custom vcpkg
+installation, create or edit `CMakeUserPresets.json` or export `VCPKG_ROOT` and
+add it to your `PATH`.

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -4,7 +4,16 @@ setlocal
 :: Ensure MSVC build tools are available
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "VSWHERE=vswhere"
+    where %VSWHERE% >nul 2>&1
+    if %errorlevel% neq 0 (
+        set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    )
+    if not exist "%VSWHERE%" (
+        echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
+        exit /b 1
+    )
+    for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "VS_PATH=%%i"
     )
     if not defined VS_PATH (

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -4,7 +4,16 @@ setlocal
 :: Ensure MSVC build tools are available
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    for /f "usebackq tokens=*" %%i in (`vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
+    set "VSWHERE=vswhere"
+    where %VSWHERE% >nul 2>&1
+    if %errorlevel% neq 0 (
+        set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    )
+    if not exist "%VSWHERE%" (
+        echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
+        exit /b 1
+    )
+    for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "VS_PATH=%%i"
     )
     if not defined VS_PATH (


### PR DESCRIPTION
## Summary
- detect `vswhere.exe` in Windows build scripts even when not on PATH
- document automatic `vswhere` lookup in README and usage summary

## Testing
- `bash scripts/compile_linux.sh` *(fails: [ERROR] VCPKG_ROOT not set. Run install_linux.sh first.)*


------
https://chatgpt.com/codex/tasks/task_e_689bf757ad8883259790df8f29279c1b