### PR TITLE
fix: improve vswhere detection on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ scripts\install_win.bat
 scripts\build_win.bat
 ```
 
-The build script automatically locates `vswhere.exe` (falling back to the
-default Visual Studio Installer path when it's not on `PATH`) to find the
-newest Visual Studio installation. It then calls `VsDevCmd.bat` so `cl.exe`
+The build script automatically locates `vswhere.exe` using the `VSWHERE`
+environment variable, the `PATH`, standard Visual Studio Installer
+directories or a Chocolatey installation before falling back to the default
+location. It then calls `VsDevCmd.bat` so `cl.exe`
 is available. Visual Studio Build Tools must be installed but the script can
 be run from a normal command prompt.
 

--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -104,8 +104,9 @@ cmake --build --preset vcpkg
 ```
 
 The default preset uses `VCPKG_ROOT` to locate vcpkg. On Windows the build
-script locates `vswhere.exe` (falling back to the standard Visual Studio
-Installer directory if needed) and invokes `VsDevCmd.bat` so `cl.exe` is
-available without launching a dedicated developer shell. To use a custom vcpkg
-installation, create or edit `CMakeUserPresets.json` or export `VCPKG_ROOT` and
-add it to your `PATH`.
+script locates `vswhere.exe` using the `VSWHERE` environment variable, the
+`PATH`, common Visual Studio Installer directories or a Chocolatey install
+before falling back to the standard location, then invokes `VsDevCmd.bat` so
+`cl.exe` is available without launching a dedicated developer shell. To use a
+custom vcpkg installation, create or edit `CMakeUserPresets.json` or export
+`VCPKG_ROOT` and add it to your `PATH`.

--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -4,15 +4,20 @@ setlocal
 :: Ensure MSVC build tools are available
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    set "VSWHERE=vswhere"
-    where %VSWHERE% >nul 2>&1
-    if %errorlevel% neq 0 (
-        set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    rem Locate vswhere using multiple strategies
+    set "VSWHERE_PATH="
+    if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
+    if not defined VSWHERE_PATH (
+        for %%i in (vswhere.exe) do if exist "%%~$PATH:i" set "VSWHERE_PATH=%%~$PATH:i"
     )
-    if not exist "%VSWHERE%" (
+    if not defined VSWHERE_PATH if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    if not defined VSWHERE_PATH if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+    if not defined VSWHERE_PATH if defined ChocolateyInstall if exist "%ChocolateyInstall%\bin\vswhere.exe" set "VSWHERE_PATH=%ChocolateyInstall%\bin\vswhere.exe"
+    if not defined VSWHERE_PATH (
         echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    set "VSWHERE=%VSWHERE_PATH%"
     for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "VS_PATH=%%i"
     )

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -4,15 +4,20 @@ setlocal
 :: Ensure MSVC build tools are available
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    set "VSWHERE=vswhere"
-    where %VSWHERE% >nul 2>&1
-    if %errorlevel% neq 0 (
-        set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    rem Locate vswhere using multiple strategies
+    set "VSWHERE_PATH="
+    if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
+    if not defined VSWHERE_PATH (
+        for %%i in (vswhere.exe) do if exist "%%~$PATH:i" set "VSWHERE_PATH=%%~$PATH:i"
     )
-    if not exist "%VSWHERE%" (
+    if not defined VSWHERE_PATH if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+    if not defined VSWHERE_PATH if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+    if not defined VSWHERE_PATH if defined ChocolateyInstall if exist "%ChocolateyInstall%\bin\vswhere.exe" set "VSWHERE_PATH=%ChocolateyInstall%\bin\vswhere.exe"
+    if not defined VSWHERE_PATH (
         echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    set "VSWHERE=%VSWHERE_PATH%"
     for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "VS_PATH=%%i"
     )


### PR DESCRIPTION
## Summary
- make Windows build scripts detect `vswhere` via environment variable, PATH, installer and Chocolatey
- document the new detection order in README and usage summary

## Testing
- `cmd.exe /c scripts/build_win.bat` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bf8f24fb0832593a01ddaabcceb8f