### PR TITLE
build: add verbose logging to Windows scripts

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -1,9 +1,12 @@
 @echo off
 setlocal
 
-:: Ensure MSVC build tools are available
+echo [INFO] Starting Windows build script...
+echo [INFO] Checking for MSVC build tools...
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
+    echo [WARN] cl compiler not found in PATH.
+    echo [INFO] Attempting to locate Visual Studio with vswhere...
     rem Locate vswhere using multiple strategies
     set "VSWHERE_PATH="
     if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
@@ -17,6 +20,7 @@ if %errorlevel% neq 0 (
         echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    echo [INFO] Found vswhere at "%VSWHERE_PATH%"
     set "VSWHERE=%VSWHERE_PATH%"
     for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "VS_PATH=%%i"
@@ -25,9 +29,11 @@ if %errorlevel% neq 0 (
         echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    echo [INFO] Initializing Visual Studio environment from "%VS_PATH%"
     call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
 )
 
+echo [INFO] Resolving VCPKG_ROOT...
 if "%VCPKG_ROOT%"=="" (
     set "SCRIPT_DIR=%~dp0"
     if exist "%SCRIPT_DIR%..\vcpkg\vcpkg.exe" (
@@ -37,14 +43,23 @@ if "%VCPKG_ROOT%"=="" (
         exit /b 1
     )
 )
+echo [INFO] Using VCPKG_ROOT=%VCPKG_ROOT%
 
+echo [INFO] Cleaning previous build artifacts...
 rmdir /s /q build\vcpkg 2>nul
+
+echo [INFO] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+
+echo [INFO] Building project...
 cmake --build build\vcpkg --config Release || exit /b 1
+
+echo [INFO] Running tests...
 ctest --test-dir build\vcpkg -C Release || exit /b 1
 
+echo [INFO] Build and tests completed successfully.
 endlocal
 

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -1,9 +1,12 @@
 @echo off
 setlocal
 
-:: Ensure MSVC build tools are available
+echo [INFO] Starting Windows compilation script...
+echo [INFO] Checking for MSVC build tools...
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
+    echo [WARN] cl compiler not found in PATH.
+    echo [INFO] Attempting to locate Visual Studio with vswhere...
     rem Locate vswhere using multiple strategies
     set "VSWHERE_PATH="
     if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
@@ -17,6 +20,7 @@ if %errorlevel% neq 0 (
         echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    echo [INFO] Found vswhere at "%VSWHERE_PATH%"
     set "VSWHERE=%VSWHERE_PATH%"
     for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
         set "VS_PATH=%%i"
@@ -25,18 +29,27 @@ if %errorlevel% neq 0 (
         echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    echo [INFO] Initializing Visual Studio environment from "%VS_PATH%"
     call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
 )
 
+echo [INFO] Using VCPKG_ROOT=%VCPKG_ROOT%
 if "%VCPKG_ROOT%"=="" (
     echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
     exit /b 1
 )
+
+echo [INFO] Cleaning previous build artifacts...
 rmdir /s /q build\vcpkg 2>nul
+
+echo [INFO] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+
+echo [INFO] Building project...
 cmake --build build\vcpkg --config Release || exit /b 1
 
+echo [INFO] Compilation finished successfully.
 endlocal


### PR DESCRIPTION
## Summary
- add step-by-step echo messages to compile_win.bat for clearer diagnostics
- expand build_win.bat logging to show MSVC, vcpkg and test stages

## Testing
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_689c8944ff308325ae4cd7d8237f2ac1