### PR TITLE
build: add verbose windows build steps

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -1,10 +1,14 @@
 @echo off
 setlocal
 
-:: Ensure MSVC build tools are available
+echo ============================================================
+echo   AutoGitHubPullMerge Windows Build and Test
+echo ============================================================
+
+echo [1/7] Checking for MSVC build tools...
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    rem Locate vswhere using multiple strategies
+    echo     cl.exe not found in PATH. Locating via vswhere...
     set "VSWHERE_PATH="
     if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
     if not defined VSWHERE_PATH (
@@ -17,34 +21,50 @@ if %errorlevel% neq 0 (
         echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
-    set "VSWHERE=%VSWHERE_PATH%"
-    for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-        set "VS_PATH=%%i"
-    )
+    echo     vswhere found at %VSWHERE_PATH%
+    for %%i in ("%VSWHERE_PATH%") do set "VSWHERE_SHORT=%%~fsi"
+    "%VSWHERE_SHORT%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath > "%TEMP%\vs_path.txt"
+    set /p VS_PATH=<"%TEMP%\vs_path.txt"
+    del "%TEMP%\vs_path.txt"
     if not defined VS_PATH (
         echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    echo     Using Visual Studio tools at %VS_PATH%
+    echo     Initializing environment with VsDevCmd.bat...
     call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
 )
 
+echo [2/7] Verifying VCPKG_ROOT...
 if "%VCPKG_ROOT%"=="" (
     set "SCRIPT_DIR=%~dp0"
     if exist "%SCRIPT_DIR%..\vcpkg\vcpkg.exe" (
         set "VCPKG_ROOT=%SCRIPT_DIR%..\vcpkg"
+        echo     Using vcpkg at %VCPKG_ROOT%
     ) else (
         echo [ERROR] VCPKG_ROOT not set and vcpkg not found. Run scripts\install_win.bat first.
         exit /b 1
     )
+) else (
+    echo     VCPKG_ROOT is %VCPKG_ROOT%
 )
 
+echo [3/7] Cleaning previous build directory...
 rmdir /s /q build\vcpkg 2>nul
+
+echo [4/7] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+
+echo [5/7] Building project...
 cmake --build build\vcpkg --config Release || exit /b 1
+
+echo [6/7] Running tests...
 ctest --test-dir build\vcpkg -C Release || exit /b 1
+
+echo [7/7] Build and tests completed successfully.
 
 endlocal
 

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -1,10 +1,14 @@
 @echo off
 setlocal
 
-:: Ensure MSVC build tools are available
+echo ============================================================
+echo   AutoGitHubPullMerge Windows Compilation
+echo ============================================================
+
+echo [1/6] Checking for MSVC build tools...
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    rem Locate vswhere using multiple strategies
+    echo     cl.exe not found in PATH. Locating via vswhere...
     set "VSWHERE_PATH="
     if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
     if not defined VSWHERE_PATH (
@@ -17,26 +21,40 @@ if %errorlevel% neq 0 (
         echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
-    set "VSWHERE=%VSWHERE_PATH%"
-    for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do (
-        set "VS_PATH=%%i"
-    )
+    echo     vswhere found at %VSWHERE_PATH%
+    for %%i in ("%VSWHERE_PATH%") do set "VSWHERE_SHORT=%%~fsi"
+    "%VSWHERE_SHORT%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath > "%TEMP%\vs_path.txt"
+    set /p VS_PATH=<"%TEMP%\vs_path.txt"
+    del "%TEMP%\vs_path.txt"
     if not defined VS_PATH (
         echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
         exit /b 1
     )
+    echo     Using Visual Studio tools at %VS_PATH%
+    echo     Initializing environment with VsDevCmd.bat...
     call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
 )
 
+echo [2/6] Verifying VCPKG_ROOT...
 if "%VCPKG_ROOT%"=="" (
     echo [ERROR] VCPKG_ROOT not set. Run install_win.bat first.
     exit /b 1
+) else (
+    echo     VCPKG_ROOT is %VCPKG_ROOT%
 )
+
+echo [3/6] Cleaning previous build directory...
 rmdir /s /q build\vcpkg 2>nul
+
+echo [4/6] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+
+echo [5/6] Building project...
 cmake --build build\vcpkg --config Release || exit /b 1
+
+echo [6/6] Compilation complete.
 
 endlocal


### PR DESCRIPTION
## Summary
- add detailed progress messages to Windows compilation script
- add step-by-step logging and vswhere handling to Windows build script

## Testing
- `make build` (fails: VCPKG_ROOT not set)


------
https://chatgpt.com/codex/tasks/task_e_689c8944ff308325ae4cd7d8237f2ac1