### PR TITLE
fix(windows): search common MSVC locations for cl

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -8,31 +8,36 @@ echo ============================================================
 echo [1/7] Checking for MSVC build tools...
 where cl >nul 2>&1
 if %errorlevel% neq 0 (
-    echo     cl.exe not found in PATH. Locating via vswhere...
-    set "VSWHERE_PATH="
-    if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
-    if not defined VSWHERE_PATH (
-        for %%i in (vswhere.exe) do if exist "%%~$PATH:i" set "VSWHERE_PATH=%%~$PATH:i"
+    echo     cl.exe not found in PATH. Searching common locations...
+    call :find_cl
+    if defined CL_PATH (
+        call :setup_msvc
+    ) else (
+        echo     cl.exe not found. Locating via vswhere...
+        set "VSWHERE_PATH="
+        if defined VSWHERE if exist "%VSWHERE%" set "VSWHERE_PATH=%VSWHERE%"
+        if not defined VSWHERE_PATH (
+            for %%i in (vswhere.exe) do if exist "%%~$PATH:i" set "VSWHERE_PATH=%%~$PATH:i"
+        )
+        if not defined VSWHERE_PATH if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+        if not defined VSWHERE_PATH if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
+        if not defined VSWHERE_PATH if defined ChocolateyInstall if exist "%ChocolateyInstall%\bin\vswhere.exe" set "VSWHERE_PATH=%ChocolateyInstall%\bin\vswhere.exe"
+        if not defined VSWHERE_PATH (
+            echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
+            exit /b 1
+        )
+        echo     vswhere found at %VSWHERE_PATH%
+        "%VSWHERE_PATH%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath > "%TEMP%\vs_path.txt"
+        set /p VS_PATH=<"%TEMP%\vs_path.txt"
+        del "%TEMP%\vs_path.txt"
+        if not defined VS_PATH (
+            echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
+            exit /b 1
+        )
+        echo     Using Visual Studio tools at %VS_PATH%
+        echo     Initializing environment with VsDevCmd.bat...
+        call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
     )
-    if not defined VSWHERE_PATH if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
-    if not defined VSWHERE_PATH if exist "%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe" set "VSWHERE_PATH=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe"
-    if not defined VSWHERE_PATH if defined ChocolateyInstall if exist "%ChocolateyInstall%\bin\vswhere.exe" set "VSWHERE_PATH=%ChocolateyInstall%\bin\vswhere.exe"
-    if not defined VSWHERE_PATH (
-        echo [ERROR] vswhere.exe not found. Install Visual Studio Build Tools and try again.
-        exit /b 1
-    )
-    echo     vswhere found at %VSWHERE_PATH%
-    for %%i in ("%VSWHERE_PATH%") do set "VSWHERE_SHORT=%%~fsi"
-    "%VSWHERE_SHORT%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath > "%TEMP%\vs_path.txt"
-    set /p VS_PATH=<"%TEMP%\vs_path.txt"
-    del "%TEMP%\vs_path.txt"
-    if not defined VS_PATH (
-        echo [ERROR] MSVC build tools not found. Install Visual Studio Build Tools and try again.
-        exit /b 1
-    )
-    echo     Using Visual Studio tools at %VS_PATH%
-    echo     Initializing environment with VsDevCmd.bat...
-    call "%VS_PATH%\Common7\Tools\VsDevCmd.bat" -arch=x64 || exit /b 1
 )
 
 echo [2/7] Verifying VCPKG_ROOT...
@@ -67,4 +72,28 @@ ctest --test-dir build\vcpkg -C Release || exit /b 1
 echo [7/7] Build and tests completed successfully.
 
 endlocal
+exit /b 0
+
+:find_cl
+set "CL_PATH="
+for /f "delims=" %%i in ('dir /b /s "%ProgramFiles(x86)%\Microsoft Visual Studio\*\VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe" 2^>nul') do (
+    set "CL_PATH=%%i"
+    goto :eof
+)
+for /f "delims=" %%i in ('dir /b /s "%ProgramFiles%\Microsoft Visual Studio\*\VC\Tools\MSVC\*\bin\Hostx64\x64\cl.exe" 2^>nul') do (
+    set "CL_PATH=%%i"
+    goto :eof
+)
+exit /b 0
+
+:setup_msvc
+echo     Found cl.exe at %CL_PATH%
+for %%i in ("%CL_PATH%") do set "CL_BIN_DIR=%%~dpi"
+set "PATH=%CL_BIN_DIR%;%PATH%"
+for %%i in ("%CL_BIN_DIR%..\..\..\..\..\..\..") do set "VSINSTALL=%%~fi"
+if exist "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" (
+    echo     Initializing environment with vcvars64.bat...
+    call "%VSINSTALL%\VC\Auxiliary\Build\vcvars64.bat" || exit /b 1
+)
+exit /b 0
 

--- a/scripts/install_win.bat
+++ b/scripts/install_win.bat
@@ -5,7 +5,7 @@ echo   AutoGitHubPullMerge Windows Dependency Installation
 echo ============================================================
 echo.
 echo Ensure Microsoft Visual C++ Build Tools are installed.
-echo Build scripts automatically locate MSVC using vswhere.
+echo Build scripts automatically locate MSVC from common locations or via vswhere.
 echo.
 echo [1/5] Installing required packages...
 choco install cmake git curl sqlite ninja visualstudio2022buildtools vswhere -y


### PR DESCRIPTION
## Summary
- search standard Visual Studio directories for `cl.exe` before falling back to `vswhere`
- setup MSVC environment automatically once `cl.exe` is located
- clarify Windows install script about locating MSVC from common paths or `vswhere`

## Testing
- `make lint` *(fails: No rule to make target 'lint')*
- `make test` *(fails: No rule to make target 'test')*
- `make build` *(fails: [ERROR] VCPKG_ROOT not set. Run install_linux.sh first.)*

------
https://chatgpt.com/codex/tasks/task_e_689c8d5dbe0c8325ab91ca76f96e6995