### PR TITLE
fix: auto-detect make and cmake paths

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=util.sh
+. "${SCRIPT_DIR}/util.sh"
+
+ensure_tool make
+ensure_tool cmake
+
 if [[ -z "${VCPKG_ROOT}" ]]; then
-    echo "[ERROR] VCPKG_ROOT not set. Run install_linux.sh first."
-    exit 1
+	echo "[ERROR] VCPKG_ROOT not set. Run install_linux.sh first."
+	exit 1
 fi
 
 cmake --preset vcpkg --fresh

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=util.sh
+. "${SCRIPT_DIR}/util.sh"
+
+ensure_tool make
+ensure_tool cmake
+
 if [[ -z "${VCPKG_ROOT}" ]]; then
-    echo "[ERROR] VCPKG_ROOT not set. Run install_mac.sh first."
-    exit 1
+	echo "[ERROR] VCPKG_ROOT not set. Run install_mac.sh first."
+	exit 1
 fi
 
 cmake --preset vcpkg --fresh

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=util.sh
+. "${SCRIPT_DIR}/util.sh"
+
+ensure_tool make
+ensure_tool cmake
+
 if [[ -z "${VCPKG_ROOT}" ]]; then
-    echo "[ERROR] VCPKG_ROOT not set. Run install_linux.sh first."
-    exit 1
+	echo "[ERROR] VCPKG_ROOT not set. Run install_linux.sh first."
+	exit 1
 fi
 
 cmake --preset vcpkg --fresh

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=util.sh
+. "${SCRIPT_DIR}/util.sh"
+
+ensure_tool make
+ensure_tool cmake
+
 if [[ -z "${VCPKG_ROOT}" ]]; then
-    echo "[ERROR] VCPKG_ROOT not set. Run install_mac.sh first."
-    exit 1
+	echo "[ERROR] VCPKG_ROOT not set. Run install_mac.sh first."
+	exit 1
 fi
 
 cmake --preset vcpkg --fresh

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Utility helpers for build and compile scripts
+
+ensure_tool() {
+	local tool="$1"
+	if command -v "$tool" >/dev/null 2>&1; then
+		return
+	fi
+	echo "[WARN] $tool not found in PATH. Attempting auto-detect..."
+	local found
+	found=$(find /usr/local/bin /usr/bin "$HOME/.local/bin" "$HOME/bin" -maxdepth 3 -type f -name "$tool" 2>/dev/null | head -n 1)
+	if [[ -n "$found" ]]; then
+		local dir
+		dir=$(dirname "$found")
+		echo "[INFO] Adding $dir to PATH for $tool"
+		export PATH="$dir:$PATH"
+	else
+		echo "[ERROR] $tool not found. Please install $tool."
+		exit 1
+	fi
+}


### PR DESCRIPTION
## Summary
- source new util script that auto-detects make and cmake and adds them to PATH
- ensure Linux/macOS build and compile scripts verify required tools before running

## Testing
- `shellcheck -x util.sh build_linux.sh compile_linux.sh build_mac.sh compile_mac.sh`
- `bash scripts/build_linux.sh` *(fails: `[ERROR] VCPKG_ROOT not set. Run install_linux.sh first.`)*

------
https://chatgpt.com/codex/tasks/task_e_689c8e168d3c83258c9aa45c485d86af