### PR TITLE
Quote CMake toolchain path

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -59,7 +59,7 @@ rmdir /s /q build\vcpkg 2>nul
 
 echo [4/7] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
-  -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
+  -DCMAKE_TOOLCHAIN_FILE="%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake" ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
 

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -53,7 +53,7 @@ rmdir /s /q build\vcpkg 2>nul
 
 echo [4/6] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
-  -DCMAKE_TOOLCHAIN_FILE=%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake ^
+  -DCMAKE_TOOLCHAIN_FILE="%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake" ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
 


### PR DESCRIPTION
## Summary
- Wrap CMake toolchain file path in quotes for Windows build and compile scripts to handle spaces in directory paths.

## Testing
- `cmake --preset vcpkg` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c91bf44988325990ca5345aed836a