### PR TITLE
fix(build): use static msvc runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,13 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Ensure all targets link against the static MSVC runtime when building on
+# Windows. This avoids mismatches between /MT and /MD when linking against
+# vcpkg packages built with the static triplet.
+if(MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 # Compiler flags
 if(MSVC)
   add_compile_options(/W4 /O2)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ scripts\install_win.bat
 scripts\build_win.bat
 ```
 
+The Windows build links against the static MSVC runtime to produce a
+fully self-contained executable. Ensure all dependencies are installed
+with the `x64-windows-static` vcpkg triplet to avoid `/MT` vs `/MD`
+runtime mismatches.
+
 The build script automatically locates `vswhere.exe` using the `VSWHERE`
 environment variable, the `PATH`, standard Visual Studio Installer
 directories or a Chocolatey installation before falling back to the default


### PR DESCRIPTION
## Summary
- ensure CMake links against the static MSVC runtime
- document Windows builds using the `x64-windows-static` vcpkg triplet

## Testing
- `bash scripts/install_linux.sh` *(fails: building libev:x64-linux failed)*
- `bash scripts/build_linux.sh` *(fails: vcpkg install failed)*

------
https://chatgpt.com/codex/tasks/task_e_689ccfd192748325b676cb72407e29da