### PR TITLE
fix: compile scripts generate single binary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,11 @@ else()
   add_compile_options(-Wall -Wextra -Wpedantic -O2)
 endif()
 
-enable_testing()
+include(CTest)
 
 find_package(spdlog REQUIRED)
 
 add_subdirectory(src)
-add_subdirectory(tests)
+if(BUILD_TESTING)
+  add_subdirectory(tests)
+endif()

--- a/scripts/compile_linux.sh
+++ b/scripts/compile_linux.sh
@@ -13,5 +13,5 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
 	exit 1
 fi
 
-cmake --preset vcpkg --fresh
-cmake --build --preset vcpkg
+cmake --preset vcpkg --fresh -DBUILD_TESTING=OFF
+cmake --build --preset vcpkg --target autogithubpullmerge

--- a/scripts/compile_mac.sh
+++ b/scripts/compile_mac.sh
@@ -13,5 +13,5 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
 	exit 1
 fi
 
-cmake --preset vcpkg --fresh
-cmake --build --preset vcpkg
+cmake --preset vcpkg --fresh -DBUILD_TESTING=OFF
+cmake --build --preset vcpkg --target autogithubpullmerge

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -56,12 +56,13 @@ rmdir /s /q build\vcpkg 2>nul
 
 echo [5/7] Configuring project with CMake...
 cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
+  -DBUILD_TESTING=OFF ^
   -DCMAKE_TOOLCHAIN_FILE="%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake" ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
 
 echo [6/7] Building project...
-cmake --build build\vcpkg --config Release || exit /b 1
+cmake --build build\vcpkg --config Release --target autogithubpullmerge || exit /b 1
 
 echo [7/7] Compilation complete.
 


### PR DESCRIPTION
## Summary
- make tests optional in CMake
- compile scripts only build the main autogithubpullmerge executable

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*
- `shellcheck scripts/compile_linux.sh scripts/compile_mac.sh`


------
https://chatgpt.com/codex/tasks/task_e_689cdf7e0f788325ac13039c3aeacba0