### PR TITLE
feat: expand configuration options

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -1,7 +1,9 @@
 #ifndef AUTOGITHUBPULLMERGE_CONFIG_HPP
 #define AUTOGITHUBPULLMERGE_CONFIG_HPP
 
+#include <chrono>
 #include <string>
+#include <vector>
 
 namespace agpm {
 
@@ -26,6 +28,130 @@ public:
   /// Set maximum request rate.
   void set_max_request_rate(int rate) { max_request_rate_ = rate; }
 
+  /// Get logging verbosity level.
+  const std::string &log_level() const { return log_level_; }
+
+  /// Set logging verbosity level.
+  void set_log_level(const std::string &level) { log_level_ = level; }
+
+  /// Repositories to include.
+  const std::vector<std::string> &include_repos() const {
+    return include_repos_;
+  }
+
+  /// Set repositories to include.
+  void set_include_repos(const std::vector<std::string> &repos) {
+    include_repos_ = repos;
+  }
+
+  /// Repositories to exclude.
+  const std::vector<std::string> &exclude_repos() const {
+    return exclude_repos_;
+  }
+
+  /// Set repositories to exclude.
+  void set_exclude_repos(const std::vector<std::string> &repos) {
+    exclude_repos_ = repos;
+  }
+
+  /// Whether to include merged pull requests.
+  bool include_merged() const { return include_merged_; }
+
+  /// Set inclusion of merged pull requests.
+  void set_include_merged(bool include) { include_merged_ = include; }
+
+  /// Configured API keys.
+  const std::vector<std::string> &api_keys() const { return api_keys_; }
+
+  /// Set API keys.
+  void set_api_keys(const std::vector<std::string> &keys) { api_keys_ = keys; }
+
+  /// Read API keys from stdin.
+  bool api_key_from_stream() const { return api_key_from_stream_; }
+
+  /// Enable or disable reading API keys from stdin.
+  void set_api_key_from_stream(bool from_stream) {
+    api_key_from_stream_ = from_stream;
+  }
+
+  /// URL to fetch API keys from.
+  const std::string &api_key_url() const { return api_key_url_; }
+
+  /// Set URL to fetch API keys from.
+  void set_api_key_url(const std::string &url) { api_key_url_ = url; }
+
+  /// Username for API key URL basic auth.
+  const std::string &api_key_url_user() const { return api_key_url_user_; }
+
+  /// Set username for API key URL basic auth.
+  void set_api_key_url_user(const std::string &user) {
+    api_key_url_user_ = user;
+  }
+
+  /// Password for API key URL basic auth.
+  const std::string &api_key_url_password() const {
+    return api_key_url_password_;
+  }
+
+  /// Set password for API key URL basic auth.
+  void set_api_key_url_password(const std::string &pass) {
+    api_key_url_password_ = pass;
+  }
+
+  /// Path to file containing API keys.
+  const std::string &api_key_file() const { return api_key_file_; }
+
+  /// Set path to file containing API keys.
+  void set_api_key_file(const std::string &path) { api_key_file_ = path; }
+
+  /// Path to SQLite history database.
+  const std::string &history_db() const { return history_db_; }
+
+  /// Set history database path.
+  void set_history_db(const std::string &path) { history_db_ = path; }
+
+  /// Only poll pull requests.
+  bool only_poll_prs() const { return only_poll_prs_; }
+
+  /// Set only poll pull requests flag.
+  void set_only_poll_prs(bool v) { only_poll_prs_ = v; }
+
+  /// Only poll stray branches.
+  bool only_poll_stray() const { return only_poll_stray_; }
+
+  /// Set only poll stray flag.
+  void set_only_poll_stray(bool v) { only_poll_stray_ = v; }
+
+  /// Auto reject dirty branches.
+  bool reject_dirty() const { return reject_dirty_; }
+
+  /// Set reject dirty flag.
+  void set_reject_dirty(bool v) { reject_dirty_ = v; }
+
+  /// Automatically merge pull requests.
+  bool auto_merge() const { return auto_merge_; }
+
+  /// Set auto merge flag.
+  void set_auto_merge(bool v) { auto_merge_ = v; }
+
+  /// Prefix of branches to purge after merge.
+  const std::string &purge_prefix() const { return purge_prefix_; }
+
+  /// Set purge prefix for branch deletion.
+  void set_purge_prefix(const std::string &p) { purge_prefix_ = p; }
+
+  /// Limit of pull requests to fetch.
+  int pr_limit() const { return pr_limit_; }
+
+  /// Set limit of pull requests to fetch.
+  void set_pr_limit(int limit) { pr_limit_ = limit; }
+
+  /// Only list pull requests newer than this duration.
+  std::chrono::seconds pr_since() const { return pr_since_; }
+
+  /// Set duration for filtering pull requests.
+  void set_pr_since(std::chrono::seconds since) { pr_since_ = since; }
+
   /// Load configuration from the file at `path`.
   static Config from_file(const std::string &path);
 
@@ -33,6 +159,24 @@ private:
   bool verbose_ = false;
   int poll_interval_ = 0;
   int max_request_rate_ = 60;
+  std::string log_level_ = "info";
+  std::vector<std::string> include_repos_;
+  std::vector<std::string> exclude_repos_;
+  bool include_merged_ = false;
+  std::vector<std::string> api_keys_;
+  bool api_key_from_stream_ = false;
+  std::string api_key_url_;
+  std::string api_key_url_user_;
+  std::string api_key_url_password_;
+  std::string api_key_file_;
+  std::string history_db_ = "history.db";
+  bool only_poll_prs_ = false;
+  bool only_poll_stray_ = false;
+  bool reject_dirty_ = false;
+  bool auto_merge_ = false;
+  std::string purge_prefix_;
+  int pr_limit_ = 50;
+  std::chrono::seconds pr_since_{0};
 };
 
 } // namespace agpm

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,4 +1,5 @@
 #include "config.hpp"
+#include <cctype>
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -7,6 +8,33 @@
 #include <yaml-cpp/yaml.h>
 
 namespace agpm {
+
+static std::chrono::seconds parse_duration(const std::string &str) {
+  if (str.empty())
+    return std::chrono::seconds{0};
+  char unit = str.back();
+  std::string num = str;
+  if (!std::isdigit(static_cast<unsigned char>(unit))) {
+    num.pop_back();
+  } else {
+    unit = 's';
+  }
+  long value = std::stol(num);
+  switch (std::tolower(static_cast<unsigned char>(unit))) {
+  case 's':
+    return std::chrono::seconds{value};
+  case 'm':
+    return std::chrono::seconds{value * 60};
+  case 'h':
+    return std::chrono::seconds{value * 3600};
+  case 'd':
+    return std::chrono::seconds{value * 86400};
+  case 'w':
+    return std::chrono::seconds{value * 604800};
+  default:
+    throw std::runtime_error("Invalid duration suffix");
+  }
+}
 
 Config Config::from_file(const std::string &path) {
   Config cfg;
@@ -26,6 +54,63 @@ Config Config::from_file(const std::string &path) {
     if (node["max_request_rate"]) {
       cfg.set_max_request_rate(node["max_request_rate"].as<int>());
     }
+    if (node["log_level"]) {
+      cfg.set_log_level(node["log_level"].as<std::string>());
+    }
+    if (node["include_repos"]) {
+      cfg.set_include_repos(
+          node["include_repos"].as<std::vector<std::string>>());
+    }
+    if (node["exclude_repos"]) {
+      cfg.set_exclude_repos(
+          node["exclude_repos"].as<std::vector<std::string>>());
+    }
+    if (node["include_merged"]) {
+      cfg.set_include_merged(node["include_merged"].as<bool>());
+    }
+    if (node["api_keys"]) {
+      cfg.set_api_keys(node["api_keys"].as<std::vector<std::string>>());
+    }
+    if (node["api_key_from_stream"]) {
+      cfg.set_api_key_from_stream(node["api_key_from_stream"].as<bool>());
+    }
+    if (node["api_key_url"]) {
+      cfg.set_api_key_url(node["api_key_url"].as<std::string>());
+    }
+    if (node["api_key_url_user"]) {
+      cfg.set_api_key_url_user(node["api_key_url_user"].as<std::string>());
+    }
+    if (node["api_key_url_password"]) {
+      cfg.set_api_key_url_password(
+          node["api_key_url_password"].as<std::string>());
+    }
+    if (node["api_key_file"]) {
+      cfg.set_api_key_file(node["api_key_file"].as<std::string>());
+    }
+    if (node["history_db"]) {
+      cfg.set_history_db(node["history_db"].as<std::string>());
+    }
+    if (node["only_poll_prs"]) {
+      cfg.set_only_poll_prs(node["only_poll_prs"].as<bool>());
+    }
+    if (node["only_poll_stray"]) {
+      cfg.set_only_poll_stray(node["only_poll_stray"].as<bool>());
+    }
+    if (node["reject_dirty"]) {
+      cfg.set_reject_dirty(node["reject_dirty"].as<bool>());
+    }
+    if (node["auto_merge"]) {
+      cfg.set_auto_merge(node["auto_merge"].as<bool>());
+    }
+    if (node["purge_prefix"]) {
+      cfg.set_purge_prefix(node["purge_prefix"].as<std::string>());
+    }
+    if (node["pr_limit"]) {
+      cfg.set_pr_limit(node["pr_limit"].as<int>());
+    }
+    if (node["pr_since"]) {
+      cfg.set_pr_since(parse_duration(node["pr_since"].as<std::string>()));
+    }
   } else if (ext == "json") {
     std::ifstream f(path);
     if (!f) {
@@ -41,6 +126,61 @@ Config Config::from_file(const std::string &path) {
     }
     if (j.contains("max_request_rate")) {
       cfg.set_max_request_rate(j["max_request_rate"].get<int>());
+    }
+    if (j.contains("log_level")) {
+      cfg.set_log_level(j["log_level"].get<std::string>());
+    }
+    if (j.contains("include_repos")) {
+      cfg.set_include_repos(j["include_repos"].get<std::vector<std::string>>());
+    }
+    if (j.contains("exclude_repos")) {
+      cfg.set_exclude_repos(j["exclude_repos"].get<std::vector<std::string>>());
+    }
+    if (j.contains("include_merged")) {
+      cfg.set_include_merged(j["include_merged"].get<bool>());
+    }
+    if (j.contains("api_keys")) {
+      cfg.set_api_keys(j["api_keys"].get<std::vector<std::string>>());
+    }
+    if (j.contains("api_key_from_stream")) {
+      cfg.set_api_key_from_stream(j["api_key_from_stream"].get<bool>());
+    }
+    if (j.contains("api_key_url")) {
+      cfg.set_api_key_url(j["api_key_url"].get<std::string>());
+    }
+    if (j.contains("api_key_url_user")) {
+      cfg.set_api_key_url_user(j["api_key_url_user"].get<std::string>());
+    }
+    if (j.contains("api_key_url_password")) {
+      cfg.set_api_key_url_password(
+          j["api_key_url_password"].get<std::string>());
+    }
+    if (j.contains("api_key_file")) {
+      cfg.set_api_key_file(j["api_key_file"].get<std::string>());
+    }
+    if (j.contains("history_db")) {
+      cfg.set_history_db(j["history_db"].get<std::string>());
+    }
+    if (j.contains("only_poll_prs")) {
+      cfg.set_only_poll_prs(j["only_poll_prs"].get<bool>());
+    }
+    if (j.contains("only_poll_stray")) {
+      cfg.set_only_poll_stray(j["only_poll_stray"].get<bool>());
+    }
+    if (j.contains("reject_dirty")) {
+      cfg.set_reject_dirty(j["reject_dirty"].get<bool>());
+    }
+    if (j.contains("auto_merge")) {
+      cfg.set_auto_merge(j["auto_merge"].get<bool>());
+    }
+    if (j.contains("purge_prefix")) {
+      cfg.set_purge_prefix(j["purge_prefix"].get<std::string>());
+    }
+    if (j.contains("pr_limit")) {
+      cfg.set_pr_limit(j["pr_limit"].get<int>());
+    }
+    if (j.contains("pr_since")) {
+      cfg.set_pr_since(parse_duration(j["pr_since"].get<std::string>()));
     }
   } else {
     throw std::runtime_error("Unsupported config format");

--- a/src/config_manager.cpp
+++ b/src/config_manager.cpp
@@ -1,50 +1,9 @@
 #include "config_manager.hpp"
-#include <fstream>
-#include <stdexcept>
-
-#include <nlohmann/json.hpp>
-#include <yaml-cpp/yaml.h>
 
 namespace agpm {
 
 Config ConfigManager::load(const std::string &path) const {
-  auto pos = path.find_last_of('.');
-  if (pos == std::string::npos) {
-    throw std::runtime_error("Unknown config file extension");
-  }
-  std::string ext = path.substr(pos + 1);
-  Config cfg;
-  if (ext == "yaml" || ext == "yml") {
-    YAML::Node node = YAML::LoadFile(path);
-    if (node["verbose"]) {
-      cfg.set_verbose(node["verbose"].as<bool>());
-    }
-    if (node["poll_interval"]) {
-      cfg.set_poll_interval(node["poll_interval"].as<int>());
-    }
-    if (node["max_request_rate"]) {
-      cfg.set_max_request_rate(node["max_request_rate"].as<int>());
-    }
-  } else if (ext == "json") {
-    std::ifstream f(path);
-    if (!f) {
-      throw std::runtime_error("Failed to open config file");
-    }
-    nlohmann::json j;
-    f >> j;
-    if (j.contains("verbose")) {
-      cfg.set_verbose(j["verbose"].get<bool>());
-    }
-    if (j.contains("poll_interval")) {
-      cfg.set_poll_interval(j["poll_interval"].get<int>());
-    }
-    if (j.contains("max_request_rate")) {
-      cfg.set_max_request_rate(j["max_request_rate"].get<int>());
-    }
-  } else {
-    throw std::runtime_error("Unsupported config format");
-  }
-  return cfg;
+  return Config::from_file(path);
 }
 
 } // namespace agpm

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,29 +1,82 @@
 #include "config.hpp"
 #include <cassert>
+#include <chrono>
 #include <fstream>
 
 int main() {
-  // YAML config enabling verbose
+  // YAML config with extended options
   {
     std::ofstream f("cfg.yaml");
-    f << "verbose: true\npoll_interval: 3\nmax_request_rate: 10\n";
+    f << "verbose: true\n";
+    f << "poll_interval: 3\n";
+    f << "max_request_rate: 10\n";
+    f << "log_level: debug\n";
+    f << "include_repos:\n  - repoA\n  - repoB\n";
+    f << "exclude_repos:\n  - repoC\n";
+    f << "api_keys:\n  - a\n  - b\n";
+    f << "include_merged: true\n";
+    f << "history_db: hist.db\n";
+    f << "only_poll_prs: true\n";
+    f << "reject_dirty: true\n";
+    f << "auto_merge: true\n";
+    f << "purge_prefix: tmp/\n";
+    f << "pr_limit: 25\n";
+    f << "pr_since: 2h\n";
     f.close();
   }
   agpm::Config yaml_cfg = agpm::Config::from_file("cfg.yaml");
   assert(yaml_cfg.verbose());
   assert(yaml_cfg.poll_interval() == 3);
   assert(yaml_cfg.max_request_rate() == 10);
+  assert(yaml_cfg.log_level() == "debug");
+  assert(yaml_cfg.include_repos().size() == 2);
+  assert(yaml_cfg.include_repos()[0] == "repoA");
+  assert(yaml_cfg.exclude_repos().size() == 1);
+  assert(yaml_cfg.exclude_repos()[0] == "repoC");
+  assert(yaml_cfg.api_keys().size() == 2);
+  assert(yaml_cfg.include_merged());
+  assert(yaml_cfg.history_db() == "hist.db");
+  assert(yaml_cfg.only_poll_prs());
+  assert(yaml_cfg.reject_dirty());
+  assert(yaml_cfg.auto_merge());
+  assert(yaml_cfg.purge_prefix() == "tmp/");
+  assert(yaml_cfg.pr_limit() == 25);
+  assert(yaml_cfg.pr_since() == std::chrono::hours(2));
 
-  // JSON config disabling verbose
+  // JSON config with extended options
   {
     std::ofstream f("cfg.json");
-    f << "{\"verbose\": false, \"poll_interval\":2, \"max_request_rate\":5}";
+    f << "{";
+    f << "\"verbose\": false,";
+    f << "\"poll_interval\":2,";
+    f << "\"max_request_rate\":5,";
+    f << "\"log_level\":\"warn\",";
+    f << "\"include_repos\":[\"x\"],";
+    f << "\"exclude_repos\":[\"y\",\"z\"],";
+    f << "\"api_keys\":[\"k1\"],";
+    f << "\"history_db\":\"db.sqlite\",";
+    f << "\"only_poll_stray\":true,";
+    f << "\"purge_prefix\":\"test/\",";
+    f << "\"pr_limit\":30,";
+    f << "\"pr_since\":\"15m\"";
+    f << "}";
     f.close();
   }
   agpm::Config json_cfg = agpm::Config::from_file("cfg.json");
   assert(!json_cfg.verbose());
   assert(json_cfg.poll_interval() == 2);
   assert(json_cfg.max_request_rate() == 5);
+  assert(json_cfg.log_level() == "warn");
+  assert(json_cfg.include_repos().size() == 1);
+  assert(json_cfg.include_repos()[0] == "x");
+  assert(json_cfg.exclude_repos().size() == 2);
+  assert(json_cfg.exclude_repos()[1] == "z");
+  assert(json_cfg.api_keys().size() == 1);
+  assert(json_cfg.history_db() == "db.sqlite");
+  assert(json_cfg.only_poll_stray());
+  assert(json_cfg.purge_prefix() == "test/");
+  assert(json_cfg.pr_limit() == 30);
+  assert(json_cfg.pr_since() == std::chrono::minutes(15));
 
   return 0;
 }

--- a/tests/test_config_loading.cpp
+++ b/tests/test_config_loading.cpp
@@ -5,23 +5,33 @@
 int main() {
   {
     std::ofstream f("config.yaml");
-    f << "verbose: true\npoll_interval: 10\nmax_request_rate: 20\n";
+    f << "verbose: true\n";
+    f << "poll_interval: 10\n";
+    f << "max_request_rate: 20\n";
+    f << "log_level: debug\n";
     f.close();
   }
   agpm::Config ycfg = agpm::Config::from_file("config.yaml");
   assert(ycfg.verbose());
   assert(ycfg.poll_interval() == 10);
   assert(ycfg.max_request_rate() == 20);
+  assert(ycfg.log_level() == "debug");
 
   {
     std::ofstream f("config.json");
-    f << "{\"verbose\":false,\"poll_interval\":5,\"max_request_rate\":15}";
+    f << "{";
+    f << "\"verbose\":false,";
+    f << "\"poll_interval\":5,";
+    f << "\"max_request_rate\":15,";
+    f << "\"log_level\":\"warn\"";
+    f << "}";
     f.close();
   }
   agpm::Config jcfg = agpm::Config::from_file("config.json");
   assert(!jcfg.verbose());
   assert(jcfg.poll_interval() == 5);
   assert(jcfg.max_request_rate() == 15);
+  assert(jcfg.log_level() == "warn");
 
   return 0;
 }

--- a/tests/test_config_manager.cpp
+++ b/tests/test_config_manager.cpp
@@ -6,23 +6,33 @@ int main() {
   agpm::ConfigManager mgr;
   {
     std::ofstream f("cfg.yaml");
-    f << "verbose: true\npoll_interval: 4\nmax_request_rate: 7\n";
+    f << "verbose: true\n";
+    f << "poll_interval: 4\n";
+    f << "max_request_rate: 7\n";
+    f << "log_level: info\n";
     f.close();
   }
   agpm::Config yaml_cfg = mgr.load("cfg.yaml");
   assert(yaml_cfg.verbose());
   assert(yaml_cfg.poll_interval() == 4);
   assert(yaml_cfg.max_request_rate() == 7);
+  assert(yaml_cfg.log_level() == "info");
 
   {
     std::ofstream f("cfg.json");
-    f << "{\"verbose\": false, \"poll_interval\":1, \"max_request_rate\":3}";
+    f << "{";
+    f << "\"verbose\": false,";
+    f << "\"poll_interval\":1,";
+    f << "\"max_request_rate\":3,";
+    f << "\"log_level\":\"error\"";
+    f << "}";
     f.close();
   }
   agpm::Config json_cfg = mgr.load("cfg.json");
   assert(!json_cfg.verbose());
   assert(json_cfg.poll_interval() == 1);
   assert(json_cfg.max_request_rate() == 3);
+  assert(json_cfg.log_level() == "error");
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- expand `Config` with log level, repo filters, API key settings and more
- parse new configuration keys from YAML and JSON
- test configuration serialization for extended options

## Testing
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_689cedd27d0c832589406037332fddca