### PR TITLE
feat(cli): confirm destructive actions and categorize args

### DIFF
--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -12,29 +12,48 @@ to build the project on supported platforms.
 
 ## CLI Options
 
+### General
+
+- `-v/--verbose` - enable verbose output.
 - `--config` - path to a YAML or JSON configuration file.
 - `--log-level` - set verbosity (`trace`, `debug`, `info`, `warn`, `error`,
   `critical`, `off`).
+- `--history-db` - path to the SQLite history database.
+- `--yes` - assume "yes" to confirmation prompts.
+
+### Repository Filters
+
 - `--include`/`--exclude` - repeatable repository include/exclude filters.
+- `--include-merged` - show merged pull requests when listing (off by default).
+
+### Authentication
+
 - `--api-key` - specify a GitHub token on the command line.
 - `--api-key-from-stream` - read tokens from standard input.
 - `--api-key-url`/`--api-key-url-user`/`--api-key-url-password` - fetch tokens
   from a remote URL with optional basic authentication.
 - `--api-key-file` - load tokens from a local YAML or JSON file.
-- `--include-merged` - show merged pull requests when listing (off by default).
+
+### Polling
+
+- `--poll-interval` - how often to poll GitHub (seconds, `0` disables).
+- `--max-request-rate` - limit GitHub requests per minute.
+- `--pr-limit` - limit how many pull requests to fetch when listing.
+- `--pr-since` - only list pull requests newer than the given duration
+  (e.g. `30m`, `2h`, `1d`).
 - `--only-poll-prs` - only poll pull requests.
 - `--only-poll-stray` - only poll stray branches.
+
+### Actions
+
+The following options perform destructive actions and require confirmation
+(use `--yes` to skip the prompt):
+
 - `--reject-dirty` - automatically close dirty stray branches.
 - `--auto-merge` - merge pull requests automatically.
 - `--purge-prefix` - delete branches with this prefix once their PR is
   closed or merged.
 - `--purge-only` - skip pull request polling and only run branch cleanup.
-- `--poll-interval` - how often to poll GitHub (seconds, `0` disables).
-- `--max-request-rate` - limit GitHub requests per minute. When polling is
-  enabled a worker thread fetches pull requests at the configured interval.
-- `--pr-limit` - limit how many pull requests to fetch when listing.
-- `--pr-since` - only list pull requests newer than the given duration
-  (e.g. `30m`, `2h`, `1d`).
 
 ## Stray Branch Management
 

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -12,6 +12,7 @@ struct CliOptions {
   bool verbose = false;           ///< Enables verbose output
   std::string config_file;        ///< Optional path to configuration file
   std::string log_level = "info"; ///< Logging verbosity level
+  bool assume_yes{false};         ///< Skip confirmation prompts
   std::vector<std::string> include_repos; ///< Repositories to include
   std::vector<std::string> exclude_repos; ///< Repositories to exclude
   bool include_merged{false};             ///< Include merged pull requests

--- a/readme.md
+++ b/readme.md
@@ -150,9 +150,13 @@ API keys can be provided in several ways:
 - `--only-poll-stray` enters an isolated stray-branch purge mode.
 - `--reject-dirty` overrides protection and closes stray branches that have
   diverged.
+- `--yes` assumes "yes" to confirmation prompts.
 - `--purge-prefix` deletes branches with this prefix after their pull
   request is closed or merged, integrating cleanup into the merge workflow.
 - `--auto-merge` merges pull requests automatically.
+
+Destructive options (`--reject-dirty`, `--auto-merge`, `--purge-prefix`,
+`--purge-only`) prompt for confirmation unless `--yes` is supplied.
 
 ## Examples
 

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -112,10 +112,15 @@ int main() {
   agpm::CliOptions opts15 = agpm::parse_cli(2, argv15);
   assert(opts15.only_poll_stray);
 
+  char yes_flag[] = "--yes";
   char reject_flag[] = "--reject-dirty";
-  char *argv16b[] = {prog, reject_flag};
-  agpm::CliOptions opts16b = agpm::parse_cli(2, argv16b);
+  char *argv16b[] = {prog, yes_flag, reject_flag};
+  agpm::CliOptions opts16b = agpm::parse_cli(3, argv16b);
   assert(opts16b.reject_dirty);
+
+  char *argv_yes[] = {prog, yes_flag};
+  agpm::CliOptions opts_yes = agpm::parse_cli(2, argv_yes);
+  assert(opts_yes.assume_yes);
 
   char limit_flag[] = "--pr-limit";
   char limit_val[] = "25";
@@ -139,18 +144,18 @@ int main() {
 
   char purge_flag[] = "--purge-prefix";
   char purge_val[] = "tmp/";
-  char *argv20[] = {prog, purge_flag, purge_val};
-  agpm::CliOptions opts20 = agpm::parse_cli(3, argv20);
+  char *argv20[] = {prog, yes_flag, purge_flag, purge_val};
+  agpm::CliOptions opts20 = agpm::parse_cli(4, argv20);
   assert(opts20.purge_prefix == "tmp/");
 
   char auto_merge_flag[] = "--auto-merge";
-  char *argv21[] = {prog, auto_merge_flag};
-  agpm::CliOptions opts21 = agpm::parse_cli(2, argv21);
+  char *argv21[] = {prog, yes_flag, auto_merge_flag};
+  agpm::CliOptions opts21 = agpm::parse_cli(3, argv21);
   assert(opts21.auto_merge);
 
   char purge_only_flag[] = "--purge-only";
-  char *argv21b[] = {prog, purge_only_flag};
-  agpm::CliOptions opts21b = agpm::parse_cli(2, argv21b);
+  char *argv21b[] = {prog, yes_flag, purge_only_flag};
+  agpm::CliOptions opts21b = agpm::parse_cli(3, argv21b);
   assert(opts21b.purge_only);
 
   char *argv22[] = {prog};


### PR DESCRIPTION
## Summary
- group related CLI options for clearer help output
- require confirmation for destructive flags and add `--yes` override
- document new confirmation behavior

## Testing
- `scripts/build_linux.sh` *(fails: build in progress and time-consuming)*

------
https://chatgpt.com/codex/tasks/task_e_689cf05a82a08325be441ae7c9276e1c