### PR TITLE
feat: reject dirty branches with comparison

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -116,8 +116,8 @@ public:
                         const std::string &prefix);
 
   /**
-   * Close stray branches that have diverged from the default branch.
-   * Placeholder implementation that will be replaced with real logic.
+   * Close or delete branches that have diverged from the repository's default
+   * branch.
    */
   void close_dirty_branches(const std::string &owner, const std::string &repo);
 

--- a/tests/test_branch_cleanup.cpp
+++ b/tests/test_branch_cleanup.cpp
@@ -1,6 +1,7 @@
 #include "github_client.hpp"
 #include <cassert>
 #include <string>
+#include <unordered_map>
 
 using namespace agpm;
 
@@ -30,15 +31,78 @@ public:
   }
 };
 
+class BranchHttpClient : public HttpClient {
+public:
+  std::unordered_map<std::string, std::string> responses;
+  std::string last_deleted;
+  std::string last_url;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_url = url;
+    auto it = responses.find(url);
+    if (it != responses.end()) {
+      return it->second;
+    }
+    return "{}";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_deleted = url;
+    return "";
+  }
+};
+
 int main() {
-  auto http = std::make_unique<CleanupHttpClient>();
-  http->response =
-      "[{\"head\":{\"ref\":\"tmp/feature\"}},{\"head\":{\"ref\":\"keep\"}}]";
-  CleanupHttpClient *raw = http.get();
-  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
-  client.cleanup_branches("me", "repo", "tmp/");
-  assert(raw->last_url.find("state=closed") != std::string::npos);
-  assert(raw->last_deleted ==
-         "https://api.github.com/repos/me/repo/git/refs/heads/tmp/feature");
+  // Purge branches based on prefix.
+  {
+    auto http = std::make_unique<CleanupHttpClient>();
+    http->response =
+        "[{\"head\":{\"ref\":\"tmp/feature\"}},{\"head\":{\"ref\":\"keep\"}}]";
+    CleanupHttpClient *raw = http.get();
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    client.cleanup_branches("me", "repo", "tmp/");
+    assert(raw->last_url.find("state=closed") != std::string::npos);
+    assert(raw->last_deleted ==
+           "https://api.github.com/repos/me/repo/git/refs/heads/tmp/feature");
+  }
+
+  // Clean branch should not be deleted.
+  {
+    auto http = std::make_unique<BranchHttpClient>();
+    BranchHttpClient *raw = http.get();
+    std::string base = "https://api.github.com/repos/me/repo";
+    raw->responses[base] = "{\"default_branch\":\"main\"}";
+    raw->responses[base + "/branches"] =
+        "[{\"name\":\"main\"},{\"name\":\"feature\"}]";
+    raw->responses[base + "/compare/main...feature"] =
+        "{\"status\":\"identical\"}";
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    client.close_dirty_branches("me", "repo");
+    assert(raw->last_deleted.empty());
+  }
+
+  // Dirty branch should be deleted.
+  {
+    auto http = std::make_unique<BranchHttpClient>();
+    BranchHttpClient *raw = http.get();
+    std::string base = "https://api.github.com/repos/me/repo";
+    raw->responses[base] = "{\"default_branch\":\"main\"}";
+    raw->responses[base + "/branches"] =
+        "[{\"name\":\"main\"},{\"name\":\"feature\"}]";
+    raw->responses[base + "/compare/main...feature"] = "{\"status\":\"ahead\"}";
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    client.close_dirty_branches("me", "repo");
+    assert(raw->last_deleted == base + "/git/refs/heads/feature");
+  }
+
   return 0;
 }


### PR DESCRIPTION
## Summary
- detect branch divergence from default branch and delete dirty branches
- update API docs for dirty branch cleanup
- test clean vs dirty branch deletion

## Testing
- `g++ src/github_client.cpp tests/test_branch_cleanup.cpp -Iinclude -lcurl -std=c++20 -o test_branch_cleanup`
- `./test_branch_cleanup`


------
https://chatgpt.com/codex/tasks/task_e_689cf76ba95c8325b06b707c6e7510b1