### PR TITLE
feat(logging): add rotating file sink and config options

### DIFF
--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -12,6 +12,7 @@ struct CliOptions {
   bool verbose = false;           ///< Enables verbose output
   std::string config_file;        ///< Optional path to configuration file
   std::string log_level = "info"; ///< Logging verbosity level
+  std::string log_file;           ///< Optional path to rotating log file
   bool assume_yes{false};         ///< Skip confirmation prompts
   std::vector<std::string> include_repos; ///< Repositories to include
   std::vector<std::string> exclude_repos; ///< Repositories to exclude

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -34,6 +34,18 @@ public:
   /// Set logging verbosity level.
   void set_log_level(const std::string &level) { log_level_ = level; }
 
+  /// Get logging pattern.
+  const std::string &log_pattern() const { return log_pattern_; }
+
+  /// Set logging pattern.
+  void set_log_pattern(const std::string &pattern) { log_pattern_ = pattern; }
+
+  /// Path to rotating log file.
+  const std::string &log_file() const { return log_file_; }
+
+  /// Set path for rotating log file.
+  void set_log_file(const std::string &file) { log_file_ = file; }
+
   /// Repositories to include.
   const std::vector<std::string> &include_repos() const {
     return include_repos_;
@@ -160,6 +172,8 @@ private:
   int poll_interval_ = 0;
   int max_request_rate_ = 60;
   std::string log_level_ = "info";
+  std::string log_pattern_;
+  std::string log_file_;
   std::vector<std::string> include_repos_;
   std::vector<std::string> exclude_repos_;
   bool include_merged_ = false;

--- a/include/log.hpp
+++ b/include/log.hpp
@@ -2,11 +2,19 @@
 #define AUTOGITHUBPULLMERGE_LOG_HPP
 
 #include <spdlog/spdlog.h>
+#include <string>
 
 namespace agpm {
 
-/** Initialize global logger with the given level. */
-void init_logger(spdlog::level::level_enum level);
+/**
+ * Initialize global logger with console and optional rotating file sink.
+ *
+ * @param level   Logging verbosity level.
+ * @param pattern Log message pattern. Empty string keeps spdlog default.
+ * @param file    Optional log file path for rotating sink.
+ */
+void init_logger(spdlog::level::level_enum level,
+                 const std::string &pattern = "", const std::string &file = "");
 
 } // namespace agpm
 

--- a/readme.md
+++ b/readme.md
@@ -11,8 +11,8 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
   Linux/macOS or `pdcurses` on Windows)
 - Unit tests using Catch2
 - SQLite-based history storage with CSV/JSON export
-- Configurable logging with `--log-level`
-- Uses spdlog for colored console logging
+- Configurable logging with `--log-level` and optional `--log-file`
+- Uses spdlog for colored console and rotating file logging
 - Cross-platform compile scripts (MSVC on Windows, g++ on Linux/macOS)
 - CLI options for GitHub API keys (`--api-key`, `--api-key-from-stream`,
   `--api-key-url`, `--api-key-url-user`, `--api-key-url-password`,
@@ -123,8 +123,10 @@ doxygen docs/Doxyfile
 Logging output uses the **spdlog** library with colorized messages by default.
 The `--log-level` option controls verbosity. Valid levels include
 `trace`, `debug`, `info`, `warn`, `error`, `critical` and `off`.
+`--log-file` writes messages to a rotating log file in addition to stdout.
 Passing `--verbose` sets the logger to the `debug` level unless `--log-level`
-specifies another level.
+specifies another level. Configuration files may also define `log_level`,
+`log_pattern` and `log_file` values.
 
 ## API Key Options
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -12,17 +12,27 @@ int App::run(int argc, char **argv) {
   options_ = parse_cli(argc, argv);
   include_repos_ = options_.include_repos;
   exclude_repos_ = options_.exclude_repos;
-  spdlog::level::level_enum lvl =
-      options_.verbose ? spdlog::level::debug : spdlog::level::info;
-  try {
-    lvl = spdlog::level::from_str(options_.log_level);
-  } catch (const spdlog::spdlog_ex &) {
-    // keep default
-  }
-  init_logger(lvl);
   if (!options_.config_file.empty()) {
     config_ = Config::from_file(options_.config_file);
   }
+  std::string level_str = options_.verbose ? "debug" : "info";
+  if (options_.log_level != "info") {
+    level_str = options_.log_level;
+  } else if (config_.log_level() != "info") {
+    level_str = config_.log_level();
+  }
+  spdlog::level::level_enum lvl = spdlog::level::info;
+  try {
+    lvl = spdlog::level::from_str(level_str);
+  } catch (const spdlog::spdlog_ex &) {
+    // keep default
+  }
+  std::string pattern = config_.log_pattern();
+  std::string log_file = config_.log_file();
+  if (!options_.log_file.empty()) {
+    log_file = options_.log_file;
+  }
+  init_logger(lvl, pattern, log_file);
   PullRequestHistory history(options_.history_db);
   (void)history;
   if (options_.verbose) {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -144,6 +144,9 @@ CliOptions parse_cli(int argc, char **argv) {
       ->type_name("LEVEL")
       ->default_val("info")
       ->group("General");
+  app.add_option("--log-file", options.log_file, "Path to rotating log file")
+      ->type_name("FILE")
+      ->group("General");
   app.add_flag("-y,--yes", options.assume_yes,
                "Assume yes to confirmation prompts")
       ->group("General");

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -57,6 +57,12 @@ Config Config::from_file(const std::string &path) {
     if (node["log_level"]) {
       cfg.set_log_level(node["log_level"].as<std::string>());
     }
+    if (node["log_pattern"]) {
+      cfg.set_log_pattern(node["log_pattern"].as<std::string>());
+    }
+    if (node["log_file"]) {
+      cfg.set_log_file(node["log_file"].as<std::string>());
+    }
     if (node["include_repos"]) {
       cfg.set_include_repos(
           node["include_repos"].as<std::vector<std::string>>());
@@ -129,6 +135,12 @@ Config Config::from_file(const std::string &path) {
     }
     if (j.contains("log_level")) {
       cfg.set_log_level(j["log_level"].get<std::string>());
+    }
+    if (j.contains("log_pattern")) {
+      cfg.set_log_pattern(j["log_pattern"].get<std::string>());
+    }
+    if (j.contains("log_file")) {
+      cfg.set_log_file(j["log_file"].get<std::string>());
     }
     if (j.contains("include_repos")) {
       cfg.set_include_repos(j["include_repos"].get<std::vector<std::string>>());

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,15 +1,28 @@
 #include "log.hpp"
+#include <spdlog/sinks/rotating_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+#include <vector>
 
 namespace agpm {
 
-void init_logger(spdlog::level::level_enum level) {
+void init_logger(spdlog::level::level_enum level, const std::string &pattern,
+                 const std::string &file) {
   auto logger = spdlog::get("agpm");
   if (!logger) {
-    logger = spdlog::stdout_color_mt("agpm");
+    std::vector<spdlog::sink_ptr> sinks;
+    sinks.push_back(std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
+    if (!file.empty()) {
+      sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+          file, 1024 * 1024 * 5, 3));
+    }
+    logger =
+        std::make_shared<spdlog::logger>("agpm", sinks.begin(), sinks.end());
     spdlog::set_default_logger(logger);
   }
   logger->set_level(level);
+  if (!pattern.empty()) {
+    spdlog::set_pattern(pattern);
+  }
 }
 
 } // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,3 +76,7 @@ add_test(NAME branch_cleanup_test COMMAND test_branch_cleanup)
 add_executable(test_auto_merge test_auto_merge.cpp)
 target_link_libraries(test_auto_merge PRIVATE autogithubpullmerge_lib)
 add_test(NAME auto_merge_test COMMAND test_auto_merge)
+
+add_executable(test_log test_log.cpp)
+target_link_libraries(test_log PRIVATE autogithubpullmerge_lib)
+add_test(NAME log_test COMMAND test_log)

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -26,6 +26,12 @@ int main() {
   agpm::CliOptions opts4 = agpm::parse_cli(3, argv4);
   assert(opts4.log_level == "debug");
 
+  char log_file_flag[] = "--log-file";
+  char path[] = "app.log";
+  char *argv4b[] = {prog, log_file_flag, path};
+  agpm::CliOptions opts4b = agpm::parse_cli(3, argv4b);
+  assert(opts4b.log_file == "app.log");
+
   char *argv5[] = {prog};
   agpm::CliOptions opts5 = agpm::parse_cli(1, argv5);
   assert(opts5.log_level == "info");

--- a/tests/test_log.cpp
+++ b/tests/test_log.cpp
@@ -1,0 +1,22 @@
+#include "log.hpp"
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <spdlog/spdlog.h>
+
+int main() {
+  const char *path = "test.log";
+  std::remove(path);
+  agpm::init_logger(spdlog::level::info, "", path);
+  spdlog::debug("debug message");
+  spdlog::info("info message");
+  spdlog::shutdown();
+  std::ifstream f(path);
+  assert(f.good());
+  std::string content((std::istreambuf_iterator<char>(f)),
+                      std::istreambuf_iterator<char>());
+  assert(content.find("info message") != std::string::npos);
+  assert(content.find("debug message") == std::string::npos);
+  std::remove(path);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- allow specifying log file via `--log-file` and config
- support rotating file sink with configurable pattern and level
- add tests checking log file output and CLI parsing

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*
- `cmake -S . -B build` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cfb4de994832596eb4d2d0e48fabd