### PR TITLE
Start poller and TUI using parsed options

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -1,7 +1,6 @@
 #include "app.hpp"
 #include "cli.hpp"
 #include "config.hpp"
-#include "history.hpp"
 #include "log.hpp"
 #include <cstdlib>
 #include <spdlog/spdlog.h>
@@ -33,8 +32,6 @@ int App::run(int argc, char **argv) {
     log_file = options_.log_file;
   }
   init_logger(lvl, pattern, log_file);
-  PullRequestHistory history(options_.history_db);
-  (void)history;
   if (options_.verbose) {
     spdlog::debug("Verbose mode enabled");
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,79 @@
 #include "app.hpp"
 #include "github_client.hpp"
 #include "github_poller.hpp"
+#include "history.hpp"
 #include "tui.hpp"
+
+#include <string>
+#include <utility>
+#include <vector>
 
 int main(int argc, char **argv) {
   agpm::App app;
   int ret = app.run(argc, argv);
   if (ret == 0) {
-    agpm::GitHubClient client("", nullptr);
-    agpm::GitHubPoller poller(client, {}, 1000, 60);
+    const auto &opts = app.options();
+    const auto &cfg = app.config();
+
+    std::string token;
+    if (!opts.api_keys.empty()) {
+      token = opts.api_keys.front();
+    } else if (!cfg.api_keys().empty()) {
+      token = cfg.api_keys().front();
+    }
+
+    std::vector<std::string> include =
+        !opts.include_repos.empty() ? opts.include_repos : cfg.include_repos();
+    std::vector<std::string> exclude =
+        !opts.exclude_repos.empty() ? opts.exclude_repos : cfg.exclude_repos();
+
+    int max_rate = opts.max_request_rate != 60 ? opts.max_request_rate
+                                               : cfg.max_request_rate();
+    if (max_rate <= 0)
+      max_rate = 60;
+    int delay_ms = max_rate > 0 ? 60000 / max_rate : 0;
+
+    agpm::GitHubClient client(token, nullptr, include, exclude, delay_ms);
+
+    int interval =
+        opts.poll_interval != 0 ? opts.poll_interval : cfg.poll_interval();
+    int interval_ms = interval * 1000;
+
+    bool only_poll_prs = opts.only_poll_prs || cfg.only_poll_prs();
+    bool only_poll_stray = opts.only_poll_stray || cfg.only_poll_stray();
+    bool reject_dirty = opts.reject_dirty || cfg.reject_dirty();
+    std::string purge_prefix =
+        !opts.purge_prefix.empty() ? opts.purge_prefix : cfg.purge_prefix();
+    bool auto_merge = opts.auto_merge || cfg.auto_merge();
+    bool purge_only = opts.purge_only || cfg.purge_only();
+
+    std::vector<std::pair<std::string, std::string>> repos;
+    for (const auto &r : include) {
+      auto pos = r.find('/');
+      if (pos != std::string::npos) {
+        repos.emplace_back(r.substr(0, pos), r.substr(pos + 1));
+      }
+    }
+
+    std::string history_db =
+        !opts.history_db.empty() ? opts.history_db : cfg.history_db();
+    agpm::PullRequestHistory history(history_db);
+    (void)history;
+
+    agpm::GitHubPoller poller(client, repos, interval_ms, max_rate,
+                              only_poll_prs, only_poll_stray, reject_dirty,
+                              purge_prefix, auto_merge, purge_only);
     agpm::Tui ui(client, poller);
-    ui.init();
-    ui.run();
+    poller.start();
+    try {
+      ui.init();
+      ui.run();
+    } catch (...) {
+      poller.stop();
+      ui.cleanup();
+      throw;
+    }
+    poller.stop();
     ui.cleanup();
   }
   return ret;

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -126,13 +126,11 @@ void Tui::handle_key(int ch) {
 
 void Tui::run() {
   running_ = true;
-  poller_.start();
   while (running_) {
     draw();
     int ch = getch();
     handle_key(ch);
   }
-  poller_.stop();
 }
 
 void Tui::cleanup() {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -1,7 +1,14 @@
 #include "app.hpp"
 #include "config.hpp"
+#include "github_client.hpp"
+#include "github_poller.hpp"
+#include "history.hpp"
+#include "tui.hpp"
+#include <atomic>
 #include <cassert>
+#include <cstdlib>
 #include <fstream>
+#include <thread>
 #include <vector>
 
 int main() {
@@ -9,10 +16,71 @@ int main() {
   std::vector<char *> args;
   char prog[] = "tests";
   char verbose[] = "--verbose";
+  char include_flag[] = "--include";
+  char repo_arg[] = "o/r";
   args.push_back(prog);
   args.push_back(verbose);
+  args.push_back(include_flag);
+  args.push_back(repo_arg);
   assert(app.run(static_cast<int>(args.size()), args.data()) == 0);
   assert(app.options().verbose);
+
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  agpm::PullRequestHistory hist(app.options().history_db);
+  (void)hist;
+
+  class CountHttpClient : public agpm::HttpClient {
+  public:
+    std::atomic<int> &counter;
+    explicit CountHttpClient(std::atomic<int> &c) : counter(c) {}
+    std::string get(const std::string &url,
+                    const std::vector<std::string> &headers) override {
+      (void)url;
+      (void)headers;
+      ++counter;
+      return "[]";
+    }
+    std::string put(const std::string &url, const std::string &data,
+                    const std::vector<std::string> &headers) override {
+      (void)url;
+      (void)data;
+      (void)headers;
+      return "{}";
+    }
+    std::string del(const std::string &url,
+                    const std::vector<std::string> &headers) override {
+      (void)url;
+      (void)headers;
+      return {};
+    }
+  };
+
+  std::atomic<int> count{0};
+  auto http = std::make_unique<CountHttpClient>(count);
+  agpm::GitHubClient client("tok",
+                            std::unique_ptr<agpm::HttpClient>(http.release()),
+                            app.include_repos(), app.exclude_repos(), 0);
+  std::vector<std::pair<std::string, std::string>> repos;
+  for (const auto &r : app.include_repos()) {
+    auto pos = r.find('/');
+    if (pos != std::string::npos) {
+      repos.emplace_back(r.substr(0, pos), r.substr(pos + 1));
+    }
+  }
+  agpm::GitHubPoller poller(client, repos, 10, 60);
+  poller.start();
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  poller.stop();
+  assert(count > 0);
+
+  agpm::Tui ui(client, poller);
+  ui.init();
+  ui.cleanup();
 
   agpm::App app_cfg;
   std::ofstream cfg("run_config.yaml");
@@ -48,7 +116,8 @@ int main() {
   hist_args.push_back(prog4);
   hist_args.push_back(db_flag);
   hist_args.push_back(hist_file);
-  assert(hist_app.run(static_cast<int>(hist_args.size()), hist_args.data()) == 0);
+  assert(hist_app.run(static_cast<int>(hist_args.size()), hist_args.data()) ==
+         0);
   assert(hist_app.options().history_db == "hist.db");
 
   {


### PR DESCRIPTION
## Summary
- Instantiate GitHubClient, PullRequestHistory, and GitHubPoller from CLI/config options
- Start the poller and TUI after successful run with robust cleanup
- Exercise poller and TUI initialization in tests

## Testing
- `./scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*
- `bash scripts/install_linux.sh` *(incomplete: linux kernel headers required)*

------
https://chatgpt.com/codex/tasks/task_e_689d0964a994832591a82dfecb298926