### PR TITLE
feat: add TUI colors and hotkey docs

### DIFF
--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -107,10 +107,14 @@ Logging is controlled via `--log-level`. Valid levels are `trace`, `debug`,
 
 ## TUI Features
 
-A minimal curses-based TUI (`agpm::Tui`) is provided. It uses ncurses on
-Linux and macOS and PDCurses on Windows. The interface initializes the
-library, draws a simple window that displays "AGPM running" and waits for a
-key press before exiting.
+A curses-based TUI (`agpm::Tui`) displays active pull requests and recent log
+messages. It uses ncurses on Linux and macOS and PDCurses on Windows, enabling
+basic color output. The interface supports the following hotkeys:
+
+- **↑/↓** – navigate pull requests
+- **r** – refresh the list immediately
+- **m** – merge the selected pull request
+- **q** – quit the interface
 
 ## Building
 

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -25,12 +25,16 @@ void Tui::init() {
   noecho();
   keypad(stdscr, TRUE);
   curs_set(0);
-  start_color();
+  if (has_colors()) {
+    start_color();
 #if defined(COLOR_PAIR)
-  use_default_colors();
+    use_default_colors();
 #endif
-  init_pair(1, COLOR_CYAN, -1);   // highlight
-  init_pair(2, COLOR_YELLOW, -1); // logs
+    init_pair(1, COLOR_CYAN, -1);   // highlight
+    init_pair(2, COLOR_YELLOW, -1); // logs
+    init_pair(3, COLOR_GREEN, -1);  // help text
+  }
+  refresh();
 }
 
 void Tui::update_prs(const std::vector<PullRequest> &prs) {
@@ -51,6 +55,14 @@ void Tui::draw() {
     pr_win_ = newwin(h - log_h, w, 0, 0);
     log_win_ = newwin(log_h, w - help_w, h - log_h, 0);
     help_win_ = newwin(log_h, help_w, h - log_h, w - help_w);
+  }
+  if (has_colors()) {
+    wbkgd(pr_win_, COLOR_PAIR(0));
+    wbkgd(log_win_, COLOR_PAIR(0));
+    wbkgd(help_win_, COLOR_PAIR(0));
+    redrawwin(pr_win_);
+    redrawwin(log_win_);
+    redrawwin(help_win_);
   }
   // PR window
   werase(pr_win_);
@@ -89,9 +101,13 @@ void Tui::draw() {
   werase(help_win_);
   box(help_win_, 0, 0);
   mvwprintw(help_win_, 0, 2, "Hotkeys");
+  if (has_colors())
+    wattron(help_win_, COLOR_PAIR(3));
   mvwprintw(help_win_, 1, 1, "r - Refresh");
   mvwprintw(help_win_, 2, 1, "m - Merge");
   mvwprintw(help_win_, 3, 1, "q - Quit");
+  if (has_colors())
+    wattroff(help_win_, COLOR_PAIR(3));
   wrefresh(help_win_);
 }
 


### PR DESCRIPTION
## Summary
- initialize ncurses color pairs and redraw windows for the TUI
- loop handles hotkeys for quit, refresh, merge and navigation
- document available hotkeys and color support in usage docs

## Testing
- `clang-format -i src/tui.cpp`
- `./scripts/compile_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_689d10ddb2a08325ae3de457e0e413e3