### PR TITLE
feat: improve GitHub client error handling

### DIFF
--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -1,5 +1,6 @@
 #include "github_client.hpp"
 #include <cassert>
+#include <stdexcept>
 #include <string>
 
 using namespace agpm;
@@ -36,6 +37,52 @@ public:
   }
 };
 
+class InvalidJsonHttpClient : public HttpClient {
+public:
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "not json";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "not json";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "";
+  }
+};
+
+class ThrowingHttpClient : public HttpClient {
+public:
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    throw std::runtime_error("http error");
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    throw std::runtime_error("http error");
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    throw std::runtime_error("http error");
+  }
+};
+
 int main() {
   // Test listing pull requests
   auto mock = std::make_unique<MockHttpClient>();
@@ -68,6 +115,24 @@ int main() {
   GitHubClient client2("token", std::unique_ptr<HttpClient>(mock2.release()));
   bool merged = client2.merge_pull_request("owner", "repo", 1);
   assert(merged);
+
+  // Invalid JSON should return empty results / false
+  auto invalid = std::make_unique<InvalidJsonHttpClient>();
+  GitHubClient client_invalid("token",
+                              std::unique_ptr<HttpClient>(invalid.release()));
+  auto bad_prs = client_invalid.list_pull_requests("owner", "repo");
+  assert(bad_prs.empty());
+  bool bad_merge = client_invalid.merge_pull_request("owner", "repo", 1);
+  assert(!bad_merge);
+
+  // HTTP errors should be swallowed and result in defaults
+  auto throwing = std::make_unique<ThrowingHttpClient>();
+  GitHubClient client_throw("token",
+                            std::unique_ptr<HttpClient>(throwing.release()));
+  auto none_prs = client_throw.list_pull_requests("owner", "repo");
+  assert(none_prs.empty());
+  bool merge_fail = client_throw.merge_pull_request("owner", "repo", 1);
+  assert(!merge_fail);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- validate HTTP status codes after curl requests
- log and propagate JSON parse failures
- test GitHub client behavior for HTTP and JSON errors

## Testing
- `make build` *(fails: openssl requires Linux kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_689d10d375708325ba2bb21263b94bd7