### PR TITLE
feat: handle dirty branches with branch comparison

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -96,6 +96,12 @@ struct PullRequest {
   std::string title;
 };
 
+/// Representation of a repository branch.
+struct Branch {
+  std::string name;
+  std::string sha;
+};
+
 /** Simple GitHub API client. */
 class GitHubClient {
 public:
@@ -148,7 +154,12 @@ public:
    * Close or delete branches that have diverged from the repository's default
    * branch.
    */
-  void close_dirty_branches(const std::string &owner, const std::string &repo);
+  void close_dirty_branches(const std::string &owner, const std::string &repo,
+                            bool delete_dirty);
+
+  /// List branches for a repository.
+  std::vector<Branch> list_branches(const std::string &owner,
+                                    const std::string &repo);
 
 private:
   std::string token_;

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -51,10 +51,7 @@ void GitHubPoller::poll() {
       }
     }
     if (!only_poll_prs_) {
-      // Placeholder for stray branch polling logic
-      if (reject_dirty_) {
-        client_.close_dirty_branches(r.first, r.second);
-      }
+      client_.close_dirty_branches(r.first, r.second, reject_dirty_);
     }
   }
   if (pr_cb_) {

--- a/tests/test_branch_cleanup.cpp
+++ b/tests/test_branch_cleanup.cpp
@@ -35,11 +35,9 @@ class BranchHttpClient : public HttpClient {
 public:
   std::unordered_map<std::string, std::string> responses;
   std::string last_deleted;
-  std::string last_url;
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
     (void)headers;
-    last_url = url;
     auto it = responses.find(url);
     if (it != responses.end()) {
       return it->second;
@@ -82,11 +80,10 @@ int main() {
     std::string base = "https://api.github.com/repos/me/repo";
     raw->responses[base] = "{\"default_branch\":\"main\"}";
     raw->responses[base + "/branches"] =
-        "[{\"name\":\"main\"},{\"name\":\"feature\"}]";
-    raw->responses[base + "/compare/main...feature"] =
-        "{\"status\":\"identical\"}";
+        "[{\"name\":\"main\",\"commit\":{\"sha\":\"1\"}},{\"name\":\"feature\","
+        "\"commit\":{\"sha\":\"1\"}}]";
     GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
-    client.close_dirty_branches("me", "repo");
+    client.close_dirty_branches("me", "repo", true);
     assert(raw->last_deleted.empty());
   }
 
@@ -97,10 +94,10 @@ int main() {
     std::string base = "https://api.github.com/repos/me/repo";
     raw->responses[base] = "{\"default_branch\":\"main\"}";
     raw->responses[base + "/branches"] =
-        "[{\"name\":\"main\"},{\"name\":\"feature\"}]";
-    raw->responses[base + "/compare/main...feature"] = "{\"status\":\"ahead\"}";
+        "[{\"name\":\"main\",\"commit\":{\"sha\":\"1\"}},{\"name\":\"feature\","
+        "\"commit\":{\"sha\":\"2\"}}]";
     GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
-    client.close_dirty_branches("me", "repo");
+    client.close_dirty_branches("me", "repo", true);
     assert(raw->last_deleted == base + "/git/refs/heads/feature");
   }
 

--- a/tests/test_github_poller.cpp
+++ b/tests/test_github_poller.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <chrono>
 #include <thread>
+#include <unordered_map>
 
 using namespace agpm;
 
@@ -35,6 +36,34 @@ private:
   std::atomic<int> &counter;
 };
 
+class BranchHttpClient : public HttpClient {
+public:
+  std::unordered_map<std::string, std::string> responses;
+  std::string last_deleted;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    auto it = responses.find(url);
+    if (it != responses.end()) {
+      return it->second;
+    }
+    return "{}";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_deleted = url;
+    return "";
+  }
+};
+
 int main() {
   std::atomic<int> count1{0};
   auto http1 = std::make_unique<CountHttpClient>(count1);
@@ -43,7 +72,7 @@ int main() {
   poller1.start();
   std::this_thread::sleep_for(std::chrono::milliseconds(220));
   poller1.stop();
-  assert(count1 >= 3); // should run ~4 times
+  assert(count1 >= 6); // multiple GETs per poll
 
   std::atomic<int> count2{0};
   auto http2 = std::make_unique<CountHttpClient>(count2);
@@ -52,6 +81,36 @@ int main() {
   poller2.start();
   std::this_thread::sleep_for(std::chrono::milliseconds(220));
   poller2.stop();
-  assert(count2 == 1); // rate limited to first token
+  assert(count2 == 2); // rate limited to first poll (two GETs)
+
+  // Dirty branch is only warned when reject_dirty is false.
+  {
+    auto http = std::make_unique<BranchHttpClient>();
+    BranchHttpClient *raw = http.get();
+    std::string base = "https://api.github.com/repos/me/repo";
+    raw->responses[base] = "{\"default_branch\":\"main\"}";
+    raw->responses[base + "/branches"] =
+        "[{\"name\":\"main\",\"commit\":{\"sha\":\"1\"}},{\"name\":\"feature\","
+        "\"commit\":{\"sha\":\"2\"}}]";
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    GitHubPoller poller(client, {{"me", "repo"}}, 100, 120, false, true, false);
+    poller.poll_now();
+    assert(raw->last_deleted.empty());
+  }
+
+  // Dirty branch is deleted when reject_dirty is true.
+  {
+    auto http = std::make_unique<BranchHttpClient>();
+    BranchHttpClient *raw = http.get();
+    std::string base = "https://api.github.com/repos/me/repo";
+    raw->responses[base] = "{\"default_branch\":\"main\"}";
+    raw->responses[base + "/branches"] =
+        "[{\"name\":\"main\",\"commit\":{\"sha\":\"1\"}},{\"name\":\"feature\","
+        "\"commit\":{\"sha\":\"2\"}}]";
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    GitHubPoller poller(client, {{"me", "repo"}}, 100, 120, false, true, true);
+    poller.poll_now();
+    assert(raw->last_deleted == base + "/git/refs/heads/feature");
+  }
   return 0;
 }


### PR DESCRIPTION
## Summary
- list repository branches via new `GitHubClient::list_branches`
- compare branch heads to default branch to warn or delete when rejecting dirty branches
- update poller and tests to exercise dirty branch logic

## Testing
- `g++ -std=c++20 -Iinclude tests/test_github_poller.cpp src/github_poller.cpp src/github_client.cpp src/poller.cpp -lcurl -pthread -o /tmp/test_github_poller && /tmp/test_github_poller`
- `g++ -std=c++20 -Iinclude tests/test_branch_cleanup.cpp src/github_client.cpp -lcurl -pthread -o /tmp/test_branch_cleanup && /tmp/test_branch_cleanup`
- `bash scripts/compile_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_689d10df767c83259252882babdc8e4b