### PR TITLE
feat(cli): read API keys from stdin

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -248,6 +248,14 @@ CliOptions parse_cli(int argc, char **argv) {
     options.api_keys.insert(options.api_keys.end(), tokens.begin(),
                             tokens.end());
   }
+  if (options.api_key_from_stream) {
+    std::string line;
+    while (std::getline(std::cin, line)) {
+      if (!line.empty()) {
+        options.api_keys.push_back(line);
+      }
+    }
+  }
   options.pr_since = parse_duration(pr_since_str);
   bool destructive = options.reject_dirty || options.auto_merge ||
                      !options.purge_prefix.empty() || options.purge_only;

--- a/tests/test_cli_tokens.cpp
+++ b/tests/test_cli_tokens.cpp
@@ -1,6 +1,7 @@
 #include "cli.hpp"
 #include <cassert>
 #include <fstream>
+#include <sstream>
 
 int main() {
   // Load tokens from YAML file
@@ -27,6 +28,19 @@ int main() {
   assert(opts2.api_keys.size() == 2);
   assert(opts2.api_keys[0] == "c");
   assert(opts2.api_keys[1] == "d");
+
+  // Tokens from stdin
+  {
+    std::istringstream input("e\nf\n\n");
+    auto *cinbuf = std::cin.rdbuf();
+    std::cin.rdbuf(input.rdbuf());
+    char *argv3[] = {prog, const_cast<char *>("--api-key-from-stream")};
+    agpm::CliOptions opts3 = agpm::parse_cli(2, argv3);
+    std::cin.rdbuf(cinbuf);
+    assert(opts3.api_keys.size() == 2);
+    assert(opts3.api_keys[0] == "e");
+    assert(opts3.api_keys[1] == "f");
+  }
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- support reading API keys from standard input when requested
- test CLI token parsing for stdin streams

## Testing
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a242445f888325804f1972c9951a35