### PR TITLE
feat: paginate pull request listing

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace agpm {
@@ -24,6 +25,19 @@ public:
    */
   virtual std::string get(const std::string &url,
                           const std::vector<std::string> &headers) = 0;
+
+  /**
+   * Perform a HTTP GET request returning both body and response headers.
+   *
+   * @param url Request URL
+   * @param headers Additional request headers
+   * @return Pair of response body and headers
+   */
+  virtual std::pair<std::string, std::vector<std::string>>
+  get_with_headers(const std::string &url,
+                   const std::vector<std::string> &headers) {
+    return {get(url, headers), {}};
+  }
 
   /**
    * Perform a HTTP PUT request.
@@ -77,6 +91,11 @@ public:
   /// @copydoc HttpClient::get()
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override;
+
+  /// @copydoc HttpClient::get_with_headers()
+  std::pair<std::string, std::vector<std::string>>
+  get_with_headers(const std::string &url,
+                   const std::vector<std::string> &headers) override;
 
   /// @copydoc HttpClient::put()
   std::string put(const std::string &url, const std::string &data,


### PR DESCRIPTION
## Summary
- handle Link headers in GitHub client and fetch additional pages
- honor since and per_page limits when aggregating pull requests
- test pagination with multi-page mock responses

## Testing
- `cmake -S . -B build` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a24e60151083259c17f9d32be28b93