### PR TITLE
feat: enforce curl tls validation and improve error messages

### DIFF
--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -43,6 +43,11 @@ std::string CurlHttpClient::get(const std::string &url,
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+  char errbuf[CURL_ERROR_SIZE];
+  errbuf[0] = '\0';
+  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+  curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
   struct curl_slist *header_list = nullptr;
   for (const auto &h : headers) {
     header_list = curl_slist_append(header_list, h.c_str());
@@ -54,9 +59,19 @@ std::string CurlHttpClient::get(const std::string &url,
   long http_code = 0;
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
   curl_slist_free_all(header_list);
-  if (res != CURLE_OK || http_code < 200 || http_code >= 300) {
+  if (res != CURLE_OK) {
+    std::ostringstream oss;
+    oss << "curl GET failed: " << curl_easy_strerror(res);
+    if (errbuf[0] != '\0') {
+      oss << " - " << errbuf;
+    }
+    spdlog::error(oss.str());
+    throw std::runtime_error(oss.str());
+  }
+  if (http_code < 200 || http_code >= 300) {
     spdlog::error("curl GET {} failed with HTTP code {}", url, http_code);
-    throw std::runtime_error("curl GET failed");
+    throw std::runtime_error("curl GET failed with HTTP code " +
+                             std::to_string(http_code));
   }
   return response;
 }
@@ -73,6 +88,11 @@ std::string CurlHttpClient::put(const std::string &url, const std::string &data,
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+  char errbuf[CURL_ERROR_SIZE];
+  errbuf[0] = '\0';
+  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+  curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
   struct curl_slist *header_list = nullptr;
   for (const auto &h : headers) {
     header_list = curl_slist_append(header_list, h.c_str());
@@ -84,9 +104,19 @@ std::string CurlHttpClient::put(const std::string &url, const std::string &data,
   long http_code = 0;
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
   curl_slist_free_all(header_list);
-  if (res != CURLE_OK || http_code < 200 || http_code >= 300) {
+  if (res != CURLE_OK) {
+    std::ostringstream oss;
+    oss << "curl PUT failed: " << curl_easy_strerror(res);
+    if (errbuf[0] != '\0') {
+      oss << " - " << errbuf;
+    }
+    spdlog::error(oss.str());
+    throw std::runtime_error(oss.str());
+  }
+  if (http_code < 200 || http_code >= 300) {
     spdlog::error("curl PUT {} failed with HTTP code {}", url, http_code);
-    throw std::runtime_error("curl PUT failed");
+    throw std::runtime_error("curl PUT failed with HTTP code " +
+                             std::to_string(http_code));
   }
   return response;
 }
@@ -102,6 +132,11 @@ std::string CurlHttpClient::del(const std::string &url,
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response);
   curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
   curl_easy_setopt(curl, CURLOPT_TIMEOUT, 30L);
+  char errbuf[CURL_ERROR_SIZE];
+  errbuf[0] = '\0';
+  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
+  curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
   struct curl_slist *header_list = nullptr;
   for (const auto &h : headers) {
     header_list = curl_slist_append(header_list, h.c_str());
@@ -113,9 +148,19 @@ std::string CurlHttpClient::del(const std::string &url,
   long http_code = 0;
   curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
   curl_slist_free_all(header_list);
-  if (res != CURLE_OK || http_code < 200 || http_code >= 300) {
+  if (res != CURLE_OK) {
+    std::ostringstream oss;
+    oss << "curl DELETE failed: " << curl_easy_strerror(res);
+    if (errbuf[0] != '\0') {
+      oss << " - " << errbuf;
+    }
+    spdlog::error(oss.str());
+    throw std::runtime_error(oss.str());
+  }
+  if (http_code < 200 || http_code >= 300) {
     spdlog::error("curl DELETE {} failed with HTTP code {}", url, http_code);
-    throw std::runtime_error("curl DELETE failed");
+    throw std::runtime_error("curl DELETE failed with HTTP code " +
+                             std::to_string(http_code));
   }
   return response;
 }

--- a/tests/test_github_client_delay.cpp
+++ b/tests/test_github_client_delay.cpp
@@ -1,6 +1,7 @@
 #include "github_client.hpp"
 #include <cassert>
 #include <chrono>
+#include <curl/curl.h>
 #include <string>
 
 using namespace agpm;
@@ -49,6 +50,17 @@ int main() {
   auto t6 = std::chrono::steady_clock::now();
   diff = std::chrono::duration_cast<std::chrono::milliseconds>(t6 - t5).count();
   assert(diff >= 50);
+
+  try {
+    CurlHttpClient real;
+    real.get("https://nonexistent.invalid", {});
+    assert(false && "Expected exception");
+  } catch (const std::exception &e) {
+    std::string msg = e.what();
+    assert(msg.find("nonexistent.invalid") != std::string::npos);
+    assert(msg.find(curl_easy_strerror(CURLE_COULDNT_RESOLVE_HOST)) !=
+           std::string::npos);
+  }
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- ensure CurlHttpClient and CLI use CURLOPT_ERRORBUFFER, CURLOPT_FAILONERROR, and TLS verification
- include detailed curl error information when requests fail
- test that CurlHttpClient exposes error buffer and curl_easy_strerror in failure messages

## Testing
- `bash scripts/build_linux.sh` *(failed: openssl requires Linux kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_68a24f91a1048325ba7c855d216f7e56