### PR TITLE
feat: add RAII wrapper for sqlite statements

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -80,3 +80,8 @@ add_test(NAME auto_merge_test COMMAND test_auto_merge)
 add_executable(test_log test_log.cpp)
 target_link_libraries(test_log PRIVATE autogithubpullmerge_lib)
 add_test(NAME log_test COMMAND test_log)
+
+add_executable(test_statement_raii test_statement_raii.cpp)
+target_include_directories(test_statement_raii PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_link_libraries(test_statement_raii PRIVATE SQLite::SQLite3 nlohmann_json::nlohmann_json)
+add_test(NAME statement_raii_test COMMAND test_statement_raii)

--- a/tests/test_statement_raii.cpp
+++ b/tests/test_statement_raii.cpp
@@ -1,0 +1,36 @@
+#include "../src/history.cpp"
+#include <cassert>
+#include <stdexcept>
+
+using namespace agpm;
+
+int main() {
+  sqlite3 *db = nullptr;
+  assert(sqlite3_open(":memory:", &db) == SQLITE_OK);
+  assert(sqlite3_exec(db,
+                      "CREATE TABLE pull_requests(id INTEGER PRIMARY KEY, "
+                      "number INTEGER, title TEXT, merged INTEGER);",
+                      nullptr, nullptr, nullptr) == SQLITE_OK);
+
+  // Exception before stepping
+  try {
+    Statement stmt(
+        db, "INSERT INTO pull_requests(number,title,merged) VALUES(1,'t',0)");
+    throw std::runtime_error("boom");
+  } catch (const std::runtime_error &) {
+  }
+  assert(sqlite3_next_stmt(db, nullptr) == nullptr);
+
+  // Exception after stepping
+  try {
+    Statement stmt(
+        db, "INSERT INTO pull_requests(number,title,merged) VALUES(2,'t',0)");
+    sqlite3_step(stmt.get());
+    throw std::runtime_error("boom");
+  } catch (const std::runtime_error &) {
+  }
+  assert(sqlite3_next_stmt(db, nullptr) == nullptr);
+
+  sqlite3_close(db);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add RAII Statement wrapper to finalize sqlite statements automatically
- use Statement in history insertion and export helpers
- test statement finalization during exceptions

## Testing
- `cmake -S . -B build` *(fails: requires long vcpkg dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68a25b0c85f4832586edddfea329f40f