### PR TITLE
feat: track repository in pull requests

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -113,6 +113,8 @@ private:
 struct PullRequest {
   int number;
   std::string title;
+  std::string owner{};
+  std::string repo{};
 };
 
 /** Simple GitHub API client. */

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -274,6 +274,8 @@ GitHubClient::list_pull_requests(const std::string &owner,
       PullRequest pr;
       pr.number = item["number"].get<int>();
       pr.title = item["title"].get<std::string>();
+      pr.owner = owner;
+      pr.repo = repo;
       prs.push_back(pr);
       if (static_cast<int>(prs.size()) >= limit)
         break;

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -43,7 +43,7 @@ void GitHubPoller::poll() {
       all_prs.insert(all_prs.end(), prs.begin(), prs.end());
       if (auto_merge_) {
         for (const auto &pr : prs) {
-          client_.merge_pull_request(r.first, r.second, pr.number);
+          client_.merge_pull_request(pr.owner, pr.repo, pr.number);
         }
       }
       if (!purge_prefix_.empty()) {

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -121,9 +121,9 @@ void Tui::handle_key(int ch) {
     break;
   case 'm':
     if (selected_ < static_cast<int>(prs_.size())) {
-      int num = prs_[selected_].number;
-      if (client_.merge_pull_request("", "", num)) {
-        log("Merged PR #" + std::to_string(num));
+      const auto &pr = prs_[selected_];
+      if (client_.merge_pull_request(pr.owner, pr.repo, pr.number)) {
+        log("Merged PR #" + std::to_string(pr.number));
       }
     }
     break;

--- a/tests/test_auto_merge.cpp
+++ b/tests/test_auto_merge.cpp
@@ -10,6 +10,7 @@ class MergeHttpClient : public HttpClient {
 public:
   MergeHttpClient() : merge_calls(0) {}
   std::atomic<int> merge_calls;
+  std::string last_url;
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
     (void)headers;
@@ -20,9 +21,9 @@ public:
   }
   std::string put(const std::string &url, const std::string &data,
                   const std::vector<std::string> &headers) override {
-    (void)url;
     (void)data;
     (void)headers;
+    last_url = url;
     merge_calls++;
     return "{\"merged\":true}";
   }
@@ -44,5 +45,7 @@ int main() {
   std::this_thread::sleep_for(std::chrono::milliseconds(80));
   poller.stop();
   assert(raw->merge_calls > 0);
+  assert(raw->last_url.find("/repos/me/repo/pulls/1/merge") !=
+         std::string::npos);
   return 0;
 }

--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -167,6 +167,8 @@ int main() {
   assert(prs.size() == 1);
   assert(prs[0].number == 1);
   assert(prs[0].title == "Test");
+  assert(prs[0].owner == "owner");
+  assert(prs[0].repo == "repo");
 
   auto mock_include = std::make_unique<MockHttpClient>();
   mock_include->response = "[]";

--- a/tests/test_history_merge.cpp
+++ b/tests/test_history_merge.cpp
@@ -41,7 +41,9 @@ int main() {
   auto prs = client.list_pull_requests("me", "repo");
   PullRequestHistory hist("merge_test.db");
   for (const auto &pr : prs) {
-    bool merged = client.merge_pull_request("me", "repo", pr.number);
+    assert(pr.owner == "me");
+    assert(pr.repo == "repo");
+    bool merged = client.merge_pull_request(pr.owner, pr.repo, pr.number);
     hist.insert(pr.number, pr.title, merged);
   }
   hist.export_json("merge.json");

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -55,7 +55,7 @@ int main() {
   Tui ui(client, poller);
   ui.init();
 
-  ui.update_prs({{1, "Test PR"}});
+  ui.update_prs({{1, "Test PR", "o", "r"}});
   ui.draw();
   char buf[80];
   mvwinnstr(stdscr, 1, 1, buf, 79);
@@ -67,6 +67,7 @@ int main() {
 
   ui.handle_key('m');
   assert(raw->last_method == "PUT");
+  assert(raw->last_url.find("/repos/o/r/pulls/1/merge") != std::string::npos);
   assert(!ui.logs().empty());
   assert(ui.logs().back().find("Merged PR #1") != std::string::npos);
 


### PR DESCRIPTION
## Summary
- extend `PullRequest` with `owner` and `repo`
- merge actions use repository context across poller and TUI
- cover repository-aware merges in unit tests

## Testing
- `bash scripts/install_linux.sh` *(fails: vcpkg install incomplete)*
- `bash scripts/build_linux.sh` *(fails: vcpkg install failed, Ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a25afc90f08325aee0344079f6f3c0