### PR TITLE
feat: handle GitHub rate limiting

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -7,10 +7,16 @@
 #include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace agpm {
+
+/** Simple HTTP response container. */
+struct HttpResponse {
+  std::string body;                 ///< Response body
+  std::vector<std::string> headers; ///< Response headers
+  long status_code = 0;             ///< HTTP status code
+};
 
 /** Interface for performing HTTP requests. */
 class HttpClient {
@@ -31,12 +37,12 @@ public:
    *
    * @param url Request URL
    * @param headers Additional request headers
-   * @return Pair of response body and headers
+   * @return Response body, headers and status code
    */
-  virtual std::pair<std::string, std::vector<std::string>>
+  virtual HttpResponse
   get_with_headers(const std::string &url,
                    const std::vector<std::string> &headers) {
-    return {get(url, headers), {}};
+    return {get(url, headers), {}, 200};
   }
 
   /**
@@ -98,7 +104,7 @@ public:
                   const std::vector<std::string> &headers) override;
 
   /// @copydoc HttpClient::get_with_headers()
-  std::pair<std::string, std::vector<std::string>>
+  HttpResponse
   get_with_headers(const std::string &url,
                    const std::vector<std::string> &headers) override;
 
@@ -194,6 +200,7 @@ private:
 
   bool repo_allowed(const std::string &repo) const;
   void enforce_delay();
+  bool handle_rate_limit(const HttpResponse &resp);
 };
 
 } // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,6 +65,10 @@ add_executable(test_github_client_retry test_github_client_retry.cpp)
 target_link_libraries(test_github_client_retry PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_client_retry_test COMMAND test_github_client_retry)
 
+add_executable(test_github_rate_limit test_github_rate_limit.cpp)
+target_link_libraries(test_github_rate_limit PRIVATE autogithubpullmerge_lib)
+add_test(NAME github_rate_limit_test COMMAND test_github_rate_limit)
+
 add_executable(test_github_client_accept test_github_client_accept.cpp)
 target_link_libraries(test_github_client_accept PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_client_accept_test COMMAND test_github_client_accept)

--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -120,7 +120,7 @@ public:
       : old_ts(std::move(old_t)), recent1_ts(std::move(recent1_t)),
         recent2_ts(std::move(recent2_t)) {}
 
-  std::pair<std::string, std::vector<std::string>>
+  HttpResponse
   get_with_headers(const std::string &url,
                    const std::vector<std::string> &headers) override {
     (void)headers;
@@ -132,16 +132,16 @@ public:
           "\"}]";
       std::string next =
           url + (url.find('?') == std::string::npos ? "?" : "&") + "page=2";
-      return {body, {"Link: <" + next + ">; rel=\"next\""}};
+      return {body, {"Link: <" + next + ">; rel=\"next\""}, 200};
     }
     std::string body = "[{\"number\":3,\"title\":\"Newer\",\"created_at\":\"" +
                        recent2_ts + "\"}]";
-    return {body, {}};
+    return {body, {}, 200};
   }
 
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
-    return get_with_headers(url, headers).first;
+    return get_with_headers(url, headers).body;
   }
   std::string put(const std::string &url, const std::string &data,
                   const std::vector<std::string> &headers) override {

--- a/tests/test_github_rate_limit.cpp
+++ b/tests/test_github_rate_limit.cpp
@@ -1,0 +1,96 @@
+#include "github_client.hpp"
+#include <cassert>
+#include <chrono>
+#include <ctime>
+#include <string>
+#include <vector>
+
+using namespace agpm;
+
+class ResetHttpClient : public HttpClient {
+public:
+  int calls = 0;
+  HttpResponse get_with_headers(const std::string &,
+                                const std::vector<std::string> &) override {
+    ++calls;
+    if (calls == 1) {
+      long reset = std::time(nullptr) + 2;
+      return {"",
+              {"X-RateLimit-Remaining: 0",
+               "X-RateLimit-Reset: " + std::to_string(reset)},
+              403};
+    }
+    return {"[]", {}, 200};
+  }
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return ""; // unused
+  }
+  std::string put(const std::string &, const std::string &,
+                  const std::vector<std::string> &) override {
+    return "";
+  }
+  std::string del(const std::string &,
+                  const std::vector<std::string> &) override {
+    return "";
+  }
+};
+
+class RetryAfterHttpClient : public HttpClient {
+public:
+  int calls = 0;
+  HttpResponse get_with_headers(const std::string &,
+                                const std::vector<std::string> &) override {
+    ++calls;
+    if (calls == 1) {
+      return {"", {"Retry-After: 1"}, 429};
+    }
+    return {"[]", {}, 200};
+  }
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "";
+  }
+  std::string put(const std::string &, const std::string &,
+                  const std::vector<std::string> &) override {
+    return "";
+  }
+  std::string del(const std::string &,
+                  const std::vector<std::string> &) override {
+    return "";
+  }
+};
+
+int main() {
+  {
+    auto http = std::make_unique<ResetHttpClient>();
+    auto *raw = http.get();
+    GitHubClient client("tok", std::move(http));
+    auto start = std::chrono::steady_clock::now();
+    client.list_pull_requests("o", "r");
+    auto end = std::chrono::steady_clock::now();
+    auto diff =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+            .count();
+    assert(diff >= 1000);
+    assert(raw->calls == 2);
+  }
+  {
+    auto http = std::make_unique<RetryAfterHttpClient>();
+    auto *raw = http.get();
+    GitHubClient client("tok", std::move(http));
+    auto start = std::chrono::steady_clock::now();
+    client.list_pull_requests("o", "r");
+    auto end = std::chrono::steady_clock::now();
+    auto diff =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+            .count();
+    assert(diff >= 1000);
+    assert(raw->calls == 2);
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- expose HTTP response headers and status codes to callers
- back off when GitHub returns rate-limit responses
- add unit tests covering rate-limit backoff logic

## Testing
- `scripts/build_linux.sh` (fails: VCPKG_ROOT not set)
- `g++ -std=c++17 tests/test_github_rate_limit.cpp src/github_client.cpp -Iinclude -lcurl -lspdlog -lfmt -pthread -o /tmp/test_rate_limit && /tmp/test_rate_limit && echo SUCCESS`


------
https://chatgpt.com/codex/tasks/task_e_68a2633ada088325ba0439c18dadba89