### PR TITLE
fix: handle newlines in CSV export

### DIFF
--- a/tests/test_history_quotes.cpp
+++ b/tests/test_history_quotes.cpp
@@ -2,24 +2,83 @@
 #include <cassert>
 #include <cstdio>
 #include <fstream>
+#include <string>
+#include <vector>
 
 using namespace agpm;
 
 int main() {
+  auto parse_csv = [](const std::string &text) {
+    std::vector<std::vector<std::string>> rows;
+    std::vector<std::string> row;
+    std::string field;
+    bool in_quotes = false;
+    for (size_t i = 0; i < text.size(); ++i) {
+      char c = text[i];
+      if (in_quotes) {
+        if (c == '"') {
+          if (i + 1 < text.size() && text[i + 1] == '"') {
+            field += '"';
+            ++i;
+          } else {
+            in_quotes = false;
+          }
+        } else {
+          field += c;
+        }
+      } else {
+        if (c == '"') {
+          in_quotes = true;
+        } else if (c == ',') {
+          row.push_back(field);
+          field.clear();
+        } else if (c == '\n') {
+          row.push_back(field);
+          rows.push_back(row);
+          row.clear();
+          field.clear();
+        } else if (c == '\r') {
+          // ignore
+        } else {
+          field += c;
+        }
+      }
+    }
+    if (!field.empty() || !row.empty()) {
+      row.push_back(field);
+      rows.push_back(row);
+    }
+    return rows;
+  };
+
   PullRequestHistory hist("test_history_quotes.db");
   hist.insert(1, "Comma, Title", true);
   hist.insert(2, "Quote \"Title\"", false);
+  hist.insert(3, "Line1\nLine2", true);
   hist.export_csv("quotes.csv");
 
   std::ifstream csv("quotes.csv");
-  std::string line;
-  std::getline(csv, line);
-  assert(line == "number,title,merged");
-  std::getline(csv, line);
-  assert(line == "1,\"Comma, Title\",1");
-  std::getline(csv, line);
-  assert(line == "2,\"Quote \"\"Title\"\"\",0");
+  std::string content((std::istreambuf_iterator<char>(csv)),
+                      std::istreambuf_iterator<char>());
   csv.close();
+
+  auto rows = parse_csv(content);
+  assert(rows.size() == 4);
+  assert(rows[0][0] == "number");
+  assert(rows[0][1] == "title");
+  assert(rows[0][2] == "merged");
+
+  assert(rows[1][0] == "1");
+  assert(rows[1][1] == "Comma, Title");
+  assert(rows[1][2] == "1");
+
+  assert(rows[2][0] == "2");
+  assert(rows[2][1] == "Quote \"Title\"");
+  assert(rows[2][2] == "0");
+
+  assert(rows[3][0] == "3");
+  assert(rows[3][1] == "Line1\nLine2");
+  assert(rows[3][2] == "1");
 
   std::remove("test_history_quotes.db");
   std::remove("quotes.csv");


### PR DESCRIPTION
## Summary
- escape CSV fields locally to handle quotes, commas and newlines
- verify CSV export round-trips titles with special characters

## Testing
- `bash scripts/install_linux.sh` *(fails: building libev:x64-linux failed)*
- `scripts/build_linux.sh` *(fails: vcpkg install failed, libev build error)*

------
https://chatgpt.com/codex/tasks/task_e_68a2633da31c8325be811759a065795b