### PR TITLE
refactor: centralize duration parsing

### DIFF
--- a/include/util/duration.hpp
+++ b/include/util/duration.hpp
@@ -1,0 +1,21 @@
+#ifndef AUTOGITHUBPULLMERGE_UTIL_DURATION_HPP
+#define AUTOGITHUBPULLMERGE_UTIL_DURATION_HPP
+
+#include <chrono>
+#include <string>
+
+namespace agpm {
+
+/**
+ * Parse a human-readable duration string (e.g. "10s", "5m", "2h", "3d", "1w")
+ * into a std::chrono::seconds value.
+ *
+ * @param str Duration string; empty string returns zero seconds.
+ * @return Parsed duration in seconds.
+ * @throws std::runtime_error if an invalid suffix is provided.
+ */
+std::chrono::seconds parse_duration(const std::string &str);
+
+} // namespace agpm
+
+#endif // AUTOGITHUBPULLMERGE_UTIL_DURATION_HPP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(
   log.cpp
   tui.cpp
   poller.cpp
-  github_poller.cpp)
+  github_poller.cpp
+  util/duration.cpp)
 
 target_include_directories(
   autogithubpullmerge_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,7 +1,7 @@
 #include "cli.hpp"
 #include "curl/curl.h"
+#include "util/duration.hpp"
 #include <CLI/CLI.hpp>
-#include <cctype>
 #include <chrono>
 #include <cstdlib>
 #include <fstream>
@@ -114,33 +114,6 @@ static std::vector<std::string> load_tokens_from_url(const std::string &url,
     }
   }
   return tokens;
-}
-
-static std::chrono::seconds parse_duration(const std::string &str) {
-  if (str.empty())
-    return std::chrono::seconds{0};
-  char unit = str.back();
-  std::string num = str;
-  if (!std::isdigit(static_cast<unsigned char>(unit))) {
-    num.pop_back();
-  } else {
-    unit = 's';
-  }
-  long value = std::stol(num);
-  switch (std::tolower(static_cast<unsigned char>(unit))) {
-  case 's':
-    return std::chrono::seconds{value};
-  case 'm':
-    return std::chrono::seconds{value * 60};
-  case 'h':
-    return std::chrono::seconds{value * 3600};
-  case 'd':
-    return std::chrono::seconds{value * 86400};
-  case 'w':
-    return std::chrono::seconds{value * 604800};
-  default:
-    throw std::runtime_error("Invalid duration suffix");
-  }
 }
 
 CliOptions parse_cli(int argc, char **argv) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,5 @@
 #include "config.hpp"
-#include <cctype>
+#include "util/duration.hpp"
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -8,33 +8,6 @@
 #include <yaml-cpp/yaml.h>
 
 namespace agpm {
-
-static std::chrono::seconds parse_duration(const std::string &str) {
-  if (str.empty())
-    return std::chrono::seconds{0};
-  char unit = str.back();
-  std::string num = str;
-  if (!std::isdigit(static_cast<unsigned char>(unit))) {
-    num.pop_back();
-  } else {
-    unit = 's';
-  }
-  long value = std::stol(num);
-  switch (std::tolower(static_cast<unsigned char>(unit))) {
-  case 's':
-    return std::chrono::seconds{value};
-  case 'm':
-    return std::chrono::seconds{value * 60};
-  case 'h':
-    return std::chrono::seconds{value * 3600};
-  case 'd':
-    return std::chrono::seconds{value * 86400};
-  case 'w':
-    return std::chrono::seconds{value * 604800};
-  default:
-    throw std::runtime_error("Invalid duration suffix");
-  }
-}
 
 Config Config::from_file(const std::string &path) {
   Config cfg;

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -1,0 +1,35 @@
+#include "util/duration.hpp"
+
+#include <cctype>
+#include <stdexcept>
+
+namespace agpm {
+
+std::chrono::seconds parse_duration(const std::string &str) {
+  if (str.empty())
+    return std::chrono::seconds{0};
+  char unit = str.back();
+  std::string num = str;
+  if (!std::isdigit(static_cast<unsigned char>(unit))) {
+    num.pop_back();
+  } else {
+    unit = 's';
+  }
+  long value = std::stol(num);
+  switch (std::tolower(static_cast<unsigned char>(unit))) {
+  case 's':
+    return std::chrono::seconds{value};
+  case 'm':
+    return std::chrono::seconds{value * 60};
+  case 'h':
+    return std::chrono::seconds{value * 3600};
+  case 'd':
+    return std::chrono::seconds{value * 86400};
+  case 'w':
+    return std::chrono::seconds{value * 604800};
+  default:
+    throw std::runtime_error("Invalid duration suffix");
+  }
+}
+
+} // namespace agpm


### PR DESCRIPTION
## Summary
- add shared `parse_duration` helper
- use shared parser in CLI and Config
- wire new utility into build

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set; installation later required linux-libc-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68a2664810488325aa573f4887f13e0e