### PR TITLE
test(tui): add merge test with mock client

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,10 @@ add_executable(test_tui test_tui.cpp)
 target_link_libraries(test_tui PRIVATE autogithubpullmerge_lib)
 add_test(NAME tui_test COMMAND test_tui)
 
+add_executable(test_tui_merge test_tui_merge.cpp)
+target_link_libraries(test_tui_merge PRIVATE autogithubpullmerge_lib)
+add_test(NAME tui_merge_test COMMAND test_tui_merge)
+
 add_executable(test_github_filter test_github_filter.cpp)
 target_link_libraries(test_github_filter PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_filter_test COMMAND test_github_filter)

--- a/tests/test_tui_merge.cpp
+++ b/tests/test_tui_merge.cpp
@@ -1,0 +1,64 @@
+#include "github_client.hpp"
+#include "github_poller.hpp"
+#include "tui.hpp"
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+
+using namespace agpm;
+
+class MockHttpClient : public HttpClient {
+public:
+  int get_count{0};
+  std::string get_response;
+  std::string put_response;
+  std::string last_url;
+
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_url = url;
+    ++get_count;
+    return get_response;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)data;
+    (void)headers;
+    last_url = url;
+    return put_response;
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return {};
+  }
+};
+
+int main() {
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  auto mock = std::make_unique<MockHttpClient>();
+  mock->get_response = "[{\"number\":1,\"title\":\"PR\"}]";
+  mock->put_response = "{\"merged\":true}";
+  MockHttpClient *raw = mock.get();
+  GitHubClient client("token", std::unique_ptr<HttpClient>(mock.release()));
+  GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
+  Tui ui(client, poller);
+  ui.init();
+
+  auto prs = client.list_pull_requests("o", "r");
+  ui.update_prs(prs);
+  ui.handle_key('m');
+  assert(raw->last_url.find("/repos/o/r/pulls/1/merge") != std::string::npos);
+  assert(!ui.logs().empty());
+  assert(ui.logs().back().find("Merged PR #1") != std::string::npos);
+
+  ui.cleanup();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add unit test covering TUI merge via mock client
- register new TUI merge test with CMake

## Testing
- `./scripts/build_linux.sh` *(fails: VCPKG_ROOT not set / missing vcpkg setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a2662ae1b0832590258a233785d63b