### PR TITLE
feat(cli): use env token when no API keys

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,10 @@ API keys can be provided in several ways:
 - `--api-key-from-stream` to read tokens from standard input
 - `--api-key-url` to fetch tokens from a remote URL with optional basic auth
 - `--api-key-file` to load tokens from a JSON or YAML file
+- if no other tokens are supplied, `GITHUB_TOKEN` (or `AGPM_API_KEY`) from the
+  environment is used
+- explicit CLI options, files, URLs or stdin tokens override the environment
+  variable
 
 ## Polling Options
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -260,6 +260,15 @@ CliOptions parse_cli(int argc, char **argv) {
       }
     }
   }
+  if (options.api_keys.empty()) {
+    const char *env = std::getenv("GITHUB_TOKEN");
+    if (!env || env[0] == '\0') {
+      env = std::getenv("AGPM_API_KEY");
+    }
+    if (env && env[0] != '\0') {
+      options.api_keys.emplace_back(env);
+    }
+  }
   options.pr_since = parse_duration(pr_since_str);
   bool destructive = options.reject_dirty || options.auto_merge ||
                      !options.purge_prefix.empty() || options.purge_only;

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -1,6 +1,7 @@
 #include "cli.hpp"
 #include <cassert>
 #include <chrono>
+#include <cstdlib>
 #include <fstream>
 
 int main() {
@@ -81,6 +82,28 @@ int main() {
     assert(opts9.api_keys.size() == 2);
     assert(opts9.api_keys[0] == "a");
     assert(opts9.api_keys[1] == "b");
+  }
+
+  // Environment variable fallback
+  {
+    setenv("GITHUB_TOKEN", "envtok", 1);
+    char *argv_env[] = {prog};
+    agpm::CliOptions opts_env = agpm::parse_cli(1, argv_env);
+    assert(opts_env.api_keys.size() == 1);
+    assert(opts_env.api_keys[0] == "envtok");
+    unsetenv("GITHUB_TOKEN");
+  }
+
+  // Environment variable ignored when tokens supplied
+  {
+    setenv("GITHUB_TOKEN", "envtok", 1);
+    char api_flag2[] = "--api-key";
+    char key_env[] = "cmdtok";
+    char *argv_env2[] = {prog, api_flag2, key_env};
+    agpm::CliOptions opts_env2 = agpm::parse_cli(3, argv_env2);
+    assert(opts_env2.api_keys.size() == 1);
+    assert(opts_env2.api_keys[0] == "cmdtok");
+    unsetenv("GITHUB_TOKEN");
   }
 
   char stream_flag[] = "--api-key-from-stream";


### PR DESCRIPTION
## Summary
- load API token from GITHUB_TOKEN or AGPM_API_KEY when no other tokens provided
- document environment variable precedence
- test CLI environment token fallback

## Testing
- `cmake -S . -B build` *(fails: openssl requires Linux kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e4d84e483258b042ce3ba9140e4