### PR TITLE
feat: limit tui log buffer

### DIFF
--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -12,6 +12,10 @@
 
 namespace agpm {
 
+namespace {
+constexpr std::size_t kMaxLogs = 200;
+} // namespace
+
 Tui::Tui(GitHubClient &client, GitHubPoller &poller)
     : client_(client), poller_(poller) {
   poller_.set_pr_callback(
@@ -44,7 +48,12 @@ void Tui::update_prs(const std::vector<PullRequest> &prs) {
   }
 }
 
-void Tui::log(const std::string &msg) { logs_.push_back(msg); }
+void Tui::log(const std::string &msg) {
+  logs_.push_back(msg);
+  if (logs_.size() > kMaxLogs) {
+    logs_.erase(logs_.begin(), logs_.begin() + (logs_.size() - kMaxLogs));
+  }
+}
 
 void Tui::draw() {
   int h, w;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,10 @@ add_executable(test_tui_merge test_tui_merge.cpp)
 target_link_libraries(test_tui_merge PRIVATE autogithubpullmerge_lib)
 add_test(NAME tui_merge_test COMMAND test_tui_merge)
 
+add_executable(test_tui_log_limit test_tui_log_limit.cpp)
+target_link_libraries(test_tui_log_limit PRIVATE autogithubpullmerge_lib)
+add_test(NAME tui_log_limit_test COMMAND test_tui_log_limit)
+
 add_executable(test_github_filter test_github_filter.cpp)
 target_link_libraries(test_github_filter PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_filter_test COMMAND test_github_filter)

--- a/tests/test_tui_log_limit.cpp
+++ b/tests/test_tui_log_limit.cpp
@@ -1,0 +1,64 @@
+#include "github_poller.hpp"
+#include "tui.hpp"
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+
+using namespace agpm;
+
+class MockHttpClient : public HttpClient {
+public:
+  int get_count{0};
+  std::string get_response;
+  std::string put_response;
+  std::string last_method;
+  std::string last_url;
+
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    last_method = "GET";
+    last_url = url;
+    ++get_count;
+    return get_response;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)data;
+    (void)headers;
+    last_method = "PUT";
+    last_url = url;
+    return put_response;
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    last_method = "DELETE";
+    return {};
+  }
+};
+
+int main() {
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  auto mock = std::make_unique<MockHttpClient>();
+  mock->put_response = "{\"merged\":true}";
+  GitHubClient client("token", std::move(mock));
+  GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
+  Tui ui(client, poller);
+
+  for (int i = 0; i < 205; ++i) {
+    ui.update_prs({{i, "PR", "o", "r"}});
+    ui.handle_key('m');
+  }
+
+  assert(ui.logs().size() == 200);
+  assert(ui.logs().front().find("Merged PR #5") != std::string::npos);
+  assert(ui.logs().back().find("Merged PR #204") != std::string::npos);
+  return 0;
+}


### PR DESCRIPTION
## Summary
- cap stored TUI log entries and prune oldest
- add unit test ensuring log buffer trimming

## Testing
- `clang-tidy src/tui.cpp tests/test_tui_log_limit.cpp -- -Iinclude` *(fails: 'nlohmann/json.hpp' file not found)*
- `ctest --preset vcpkg` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68a26e457afc8325ae91a15b17ec2ff0