### PR TITLE
feat: support owner-qualified repo filters

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -198,7 +198,7 @@ private:
   int delay_ms_;
   std::chrono::steady_clock::time_point last_request_;
 
-  bool repo_allowed(const std::string &repo) const;
+  bool repo_allowed(const std::string &owner, const std::string &repo) const;
   void enforce_delay();
   bool handle_rate_limit(const HttpResponse &resp);
 };

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -265,13 +265,15 @@ GitHubClient::GitHubClient(std::string token, std::unique_ptr<HttpClient> http,
 
 void GitHubClient::set_delay_ms(int delay_ms) { delay_ms_ = delay_ms; }
 
-bool GitHubClient::repo_allowed(const std::string &repo) const {
+bool GitHubClient::repo_allowed(const std::string &owner,
+                                const std::string &repo) const {
+  std::string full = owner + "/" + repo;
   if (!include_repos_.empty() &&
-      std::find(include_repos_.begin(), include_repos_.end(), repo) ==
+      std::find(include_repos_.begin(), include_repos_.end(), full) ==
           include_repos_.end()) {
     return false;
   }
-  if (std::find(exclude_repos_.begin(), exclude_repos_.end(), repo) !=
+  if (std::find(exclude_repos_.begin(), exclude_repos_.end(), full) !=
       exclude_repos_.end()) {
     return false;
   }
@@ -282,7 +284,7 @@ std::vector<PullRequest>
 GitHubClient::list_pull_requests(const std::string &owner,
                                  const std::string &repo, bool include_merged,
                                  int per_page, std::chrono::seconds since) {
-  if (!repo_allowed(repo)) {
+  if (!repo_allowed(owner, repo)) {
     return {};
   }
   int limit = per_page > 0 ? per_page : 50;
@@ -383,7 +385,7 @@ GitHubClient::list_pull_requests(const std::string &owner,
 
 bool GitHubClient::merge_pull_request(const std::string &owner,
                                       const std::string &repo, int pr_number) {
-  if (!repo_allowed(repo)) {
+  if (!repo_allowed(owner, repo)) {
     return false;
   }
   enforce_delay();
@@ -404,7 +406,7 @@ bool GitHubClient::merge_pull_request(const std::string &owner,
 void GitHubClient::cleanup_branches(const std::string &owner,
                                     const std::string &repo,
                                     const std::string &prefix) {
-  if (!repo_allowed(repo) || prefix.empty()) {
+  if (!repo_allowed(owner, repo) || prefix.empty()) {
     return;
   }
   enforce_delay();
@@ -448,7 +450,7 @@ void GitHubClient::cleanup_branches(const std::string &owner,
 
 void GitHubClient::close_dirty_branches(const std::string &owner,
                                         const std::string &repo) {
-  if (!repo_allowed(repo)) {
+  if (!repo_allowed(owner, repo)) {
     return;
   }
   std::vector<std::string> headers = {"Authorization: token " + token_,

--- a/tests/test_github_filter.cpp
+++ b/tests/test_github_filter.cpp
@@ -40,10 +40,10 @@ int main() {
   http->response = "[{\"number\":1,\"title\":\"Test\"}]";
   SpyHttpClient *raw1 = http.get();
   GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()),
-                      {"allowed"}, {"skip"});
+                      {"me/allowed"}, {"me/skip"});
 
   // not allowed by include filter
-  auto prs = client.list_pull_requests("owner", "other");
+  auto prs = client.list_pull_requests("me", "other");
   assert(prs.empty());
   assert(raw1->last_method.empty());
 
@@ -51,16 +51,16 @@ int main() {
   auto http2 = std::make_unique<SpyHttpClient>();
   http2->response = "[{\"number\":2,\"title\":\"Good\"}]";
   GitHubClient client2("tok", std::unique_ptr<HttpClient>(http2.release()),
-                       {"good"}, {});
-  auto prs2 = client2.list_pull_requests("owner", "good");
+                       {"me/good"}, {});
+  auto prs2 = client2.list_pull_requests("me", "good");
   assert(prs2.size() == 1);
 
   // excluded repository
   auto http3 = std::make_unique<SpyHttpClient>();
   SpyHttpClient *raw3 = http3.get();
   GitHubClient client3("tok", std::unique_ptr<HttpClient>(http3.release()), {},
-                       {"bad"});
-  bool merged = client3.merge_pull_request("owner", "bad", 1);
+                       {"me/bad"});
+  bool merged = client3.merge_pull_request("me", "bad", 1);
   assert(!merged);
   assert(raw3->last_method.empty());
 


### PR DESCRIPTION
## Summary
- require full `owner/repo` strings in GitHubClient filters
- adjust filter call sites
- test filtering with owner-qualified names

## Testing
- `bash scripts/build_linux.sh` *(fails: vcpkg install failed: libev build failed)*
- `g++ -std=c++20 -Iinclude tests/test_github_filter.cpp src/github_client.cpp -lcurl -lpthread -lfmt -o /tmp/test_github_filter`
- `/tmp/test_github_filter`


------
https://chatgpt.com/codex/tasks/task_e_68a26e43e29c832595deecb77ecf89a5