### PR TITLE
feat: unify configuration parsing

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -2,6 +2,7 @@
 #define AUTOGITHUBPULLMERGE_CONFIG_HPP
 
 #include <chrono>
+#include <nlohmann/json_fwd.hpp>
 #include <string>
 #include <vector>
 
@@ -184,6 +185,9 @@ public:
 
   /// Load configuration from the file at `path`.
   static Config from_file(const std::string &path);
+
+  /// Build configuration from a JSON object.
+  static Config from_json(const nlohmann::json &j);
 
 private:
   bool verbose_ = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -9,8 +9,140 @@
 
 namespace agpm {
 
-Config Config::from_file(const std::string &path) {
+namespace {
+
+nlohmann::json yaml_to_json(const YAML::Node &node) {
+  using nlohmann::json;
+  switch (node.Type()) {
+  case YAML::NodeType::Null:
+    return nullptr;
+  case YAML::NodeType::Scalar: {
+    const std::string s = node.Scalar();
+    if (s == "true" || s == "True" || s == "TRUE")
+      return true;
+    if (s == "false" || s == "False" || s == "FALSE")
+      return false;
+    try {
+      size_t idx = 0;
+      long long i = std::stoll(s, &idx, 0);
+      if (idx == s.size())
+        return i;
+    } catch (...) {
+    }
+    try {
+      size_t idx = 0;
+      double d = std::stod(s, &idx);
+      if (idx == s.size())
+        return d;
+    } catch (...) {
+    }
+    return s;
+  }
+  case YAML::NodeType::Sequence: {
+    json arr = json::array();
+    for (const auto &item : node) {
+      arr.push_back(yaml_to_json(item));
+    }
+    return arr;
+  }
+  case YAML::NodeType::Map: {
+    json obj = json::object();
+    for (const auto &kv : node) {
+      obj[kv.first.as<std::string>()] = yaml_to_json(kv.second);
+    }
+    return obj;
+  }
+  default:
+    return nullptr;
+  }
+}
+
+} // namespace
+
+Config Config::from_json(const nlohmann::json &j) {
   Config cfg;
+  if (j.contains("verbose")) {
+    cfg.set_verbose(j["verbose"].get<bool>());
+  }
+  if (j.contains("poll_interval")) {
+    cfg.set_poll_interval(j["poll_interval"].get<int>());
+  }
+  if (j.contains("max_request_rate")) {
+    cfg.set_max_request_rate(j["max_request_rate"].get<int>());
+  }
+  if (j.contains("http_timeout")) {
+    cfg.set_http_timeout(j["http_timeout"].get<int>());
+  }
+  if (j.contains("http_retries")) {
+    cfg.set_http_retries(j["http_retries"].get<int>());
+  }
+  if (j.contains("log_level")) {
+    cfg.set_log_level(j["log_level"].get<std::string>());
+  }
+  if (j.contains("log_pattern")) {
+    cfg.set_log_pattern(j["log_pattern"].get<std::string>());
+  }
+  if (j.contains("log_file")) {
+    cfg.set_log_file(j["log_file"].get<std::string>());
+  }
+  if (j.contains("include_repos")) {
+    cfg.set_include_repos(j["include_repos"].get<std::vector<std::string>>());
+  }
+  if (j.contains("exclude_repos")) {
+    cfg.set_exclude_repos(j["exclude_repos"].get<std::vector<std::string>>());
+  }
+  if (j.contains("include_merged")) {
+    cfg.set_include_merged(j["include_merged"].get<bool>());
+  }
+  if (j.contains("api_keys")) {
+    cfg.set_api_keys(j["api_keys"].get<std::vector<std::string>>());
+  }
+  if (j.contains("api_key_from_stream")) {
+    cfg.set_api_key_from_stream(j["api_key_from_stream"].get<bool>());
+  }
+  if (j.contains("api_key_url")) {
+    cfg.set_api_key_url(j["api_key_url"].get<std::string>());
+  }
+  if (j.contains("api_key_url_user")) {
+    cfg.set_api_key_url_user(j["api_key_url_user"].get<std::string>());
+  }
+  if (j.contains("api_key_url_password")) {
+    cfg.set_api_key_url_password(j["api_key_url_password"].get<std::string>());
+  }
+  if (j.contains("api_key_file")) {
+    cfg.set_api_key_file(j["api_key_file"].get<std::string>());
+  }
+  if (j.contains("history_db")) {
+    cfg.set_history_db(j["history_db"].get<std::string>());
+  }
+  if (j.contains("only_poll_prs")) {
+    cfg.set_only_poll_prs(j["only_poll_prs"].get<bool>());
+  }
+  if (j.contains("only_poll_stray")) {
+    cfg.set_only_poll_stray(j["only_poll_stray"].get<bool>());
+  }
+  if (j.contains("reject_dirty")) {
+    cfg.set_reject_dirty(j["reject_dirty"].get<bool>());
+  }
+  if (j.contains("auto_merge")) {
+    cfg.set_auto_merge(j["auto_merge"].get<bool>());
+  }
+  if (j.contains("purge_prefix")) {
+    cfg.set_purge_prefix(j["purge_prefix"].get<std::string>());
+  }
+  if (j.contains("pr_limit")) {
+    cfg.set_pr_limit(j["pr_limit"].get<int>());
+  }
+  if (j.contains("pr_since")) {
+    cfg.set_pr_since(parse_duration(j["pr_since"].get<std::string>()));
+  }
+  if (j.contains("sort")) {
+    cfg.set_sort_mode(j["sort"].get<std::string>());
+  }
+  return cfg;
+}
+
+Config Config::from_file(const std::string &path) {
   auto pos = path.find_last_of('.');
   if (pos == std::string::npos) {
     throw std::runtime_error("Unknown config file extension");
@@ -18,177 +150,19 @@ Config Config::from_file(const std::string &path) {
   std::string ext = path.substr(pos + 1);
   if (ext == "yaml" || ext == "yml") {
     YAML::Node node = YAML::LoadFile(path);
-    if (node["verbose"]) {
-      cfg.set_verbose(node["verbose"].as<bool>());
-    }
-    if (node["poll_interval"]) {
-      cfg.set_poll_interval(node["poll_interval"].as<int>());
-    }
-    if (node["max_request_rate"]) {
-      cfg.set_max_request_rate(node["max_request_rate"].as<int>());
-    }
-    if (node["http_timeout"]) {
-      cfg.set_http_timeout(node["http_timeout"].as<int>());
-    }
-    if (node["http_retries"]) {
-      cfg.set_http_retries(node["http_retries"].as<int>());
-    }
-    if (node["log_level"]) {
-      cfg.set_log_level(node["log_level"].as<std::string>());
-    }
-    if (node["log_pattern"]) {
-      cfg.set_log_pattern(node["log_pattern"].as<std::string>());
-    }
-    if (node["log_file"]) {
-      cfg.set_log_file(node["log_file"].as<std::string>());
-    }
-    if (node["include_repos"]) {
-      cfg.set_include_repos(
-          node["include_repos"].as<std::vector<std::string>>());
-    }
-    if (node["exclude_repos"]) {
-      cfg.set_exclude_repos(
-          node["exclude_repos"].as<std::vector<std::string>>());
-    }
-    if (node["include_merged"]) {
-      cfg.set_include_merged(node["include_merged"].as<bool>());
-    }
-    if (node["api_keys"]) {
-      cfg.set_api_keys(node["api_keys"].as<std::vector<std::string>>());
-    }
-    if (node["api_key_from_stream"]) {
-      cfg.set_api_key_from_stream(node["api_key_from_stream"].as<bool>());
-    }
-    if (node["api_key_url"]) {
-      cfg.set_api_key_url(node["api_key_url"].as<std::string>());
-    }
-    if (node["api_key_url_user"]) {
-      cfg.set_api_key_url_user(node["api_key_url_user"].as<std::string>());
-    }
-    if (node["api_key_url_password"]) {
-      cfg.set_api_key_url_password(
-          node["api_key_url_password"].as<std::string>());
-    }
-    if (node["api_key_file"]) {
-      cfg.set_api_key_file(node["api_key_file"].as<std::string>());
-    }
-    if (node["history_db"]) {
-      cfg.set_history_db(node["history_db"].as<std::string>());
-    }
-    if (node["only_poll_prs"]) {
-      cfg.set_only_poll_prs(node["only_poll_prs"].as<bool>());
-    }
-    if (node["only_poll_stray"]) {
-      cfg.set_only_poll_stray(node["only_poll_stray"].as<bool>());
-    }
-    if (node["reject_dirty"]) {
-      cfg.set_reject_dirty(node["reject_dirty"].as<bool>());
-    }
-    if (node["auto_merge"]) {
-      cfg.set_auto_merge(node["auto_merge"].as<bool>());
-    }
-    if (node["purge_prefix"]) {
-      cfg.set_purge_prefix(node["purge_prefix"].as<std::string>());
-    }
-    if (node["pr_limit"]) {
-      cfg.set_pr_limit(node["pr_limit"].as<int>());
-    }
-    if (node["pr_since"]) {
-      cfg.set_pr_since(parse_duration(node["pr_since"].as<std::string>()));
-    }
-    if (node["sort"]) {
-      cfg.set_sort_mode(node["sort"].as<std::string>());
-    }
-  } else if (ext == "json") {
+    nlohmann::json j = yaml_to_json(node);
+    return from_json(j);
+  }
+  if (ext == "json") {
     std::ifstream f(path);
     if (!f) {
       throw std::runtime_error("Failed to open config file");
     }
     nlohmann::json j;
     f >> j;
-    if (j.contains("verbose")) {
-      cfg.set_verbose(j["verbose"].get<bool>());
-    }
-    if (j.contains("poll_interval")) {
-      cfg.set_poll_interval(j["poll_interval"].get<int>());
-    }
-    if (j.contains("max_request_rate")) {
-      cfg.set_max_request_rate(j["max_request_rate"].get<int>());
-    }
-    if (j.contains("http_timeout")) {
-      cfg.set_http_timeout(j["http_timeout"].get<int>());
-    }
-    if (j.contains("http_retries")) {
-      cfg.set_http_retries(j["http_retries"].get<int>());
-    }
-    if (j.contains("log_level")) {
-      cfg.set_log_level(j["log_level"].get<std::string>());
-    }
-    if (j.contains("log_pattern")) {
-      cfg.set_log_pattern(j["log_pattern"].get<std::string>());
-    }
-    if (j.contains("log_file")) {
-      cfg.set_log_file(j["log_file"].get<std::string>());
-    }
-    if (j.contains("include_repos")) {
-      cfg.set_include_repos(j["include_repos"].get<std::vector<std::string>>());
-    }
-    if (j.contains("exclude_repos")) {
-      cfg.set_exclude_repos(j["exclude_repos"].get<std::vector<std::string>>());
-    }
-    if (j.contains("include_merged")) {
-      cfg.set_include_merged(j["include_merged"].get<bool>());
-    }
-    if (j.contains("api_keys")) {
-      cfg.set_api_keys(j["api_keys"].get<std::vector<std::string>>());
-    }
-    if (j.contains("api_key_from_stream")) {
-      cfg.set_api_key_from_stream(j["api_key_from_stream"].get<bool>());
-    }
-    if (j.contains("api_key_url")) {
-      cfg.set_api_key_url(j["api_key_url"].get<std::string>());
-    }
-    if (j.contains("api_key_url_user")) {
-      cfg.set_api_key_url_user(j["api_key_url_user"].get<std::string>());
-    }
-    if (j.contains("api_key_url_password")) {
-      cfg.set_api_key_url_password(
-          j["api_key_url_password"].get<std::string>());
-    }
-    if (j.contains("api_key_file")) {
-      cfg.set_api_key_file(j["api_key_file"].get<std::string>());
-    }
-    if (j.contains("history_db")) {
-      cfg.set_history_db(j["history_db"].get<std::string>());
-    }
-    if (j.contains("only_poll_prs")) {
-      cfg.set_only_poll_prs(j["only_poll_prs"].get<bool>());
-    }
-    if (j.contains("only_poll_stray")) {
-      cfg.set_only_poll_stray(j["only_poll_stray"].get<bool>());
-    }
-    if (j.contains("reject_dirty")) {
-      cfg.set_reject_dirty(j["reject_dirty"].get<bool>());
-    }
-    if (j.contains("auto_merge")) {
-      cfg.set_auto_merge(j["auto_merge"].get<bool>());
-    }
-    if (j.contains("purge_prefix")) {
-      cfg.set_purge_prefix(j["purge_prefix"].get<std::string>());
-    }
-    if (j.contains("pr_limit")) {
-      cfg.set_pr_limit(j["pr_limit"].get<int>());
-    }
-    if (j.contains("pr_since")) {
-      cfg.set_pr_since(parse_duration(j["pr_since"].get<std::string>()));
-    }
-    if (j.contains("sort")) {
-      cfg.set_sort_mode(j["sort"].get<std::string>());
-    }
-  } else {
-    throw std::runtime_error("Unsupported config format");
+    return from_json(j);
   }
-  return cfg;
+  throw std::runtime_error("Unsupported config format");
 }
 
 } // namespace agpm

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,10 @@ add_executable(test_config_loading test_config_loading.cpp)
 target_link_libraries(test_config_loading PRIVATE autogithubpullmerge_lib)
 add_test(NAME config_loading_test COMMAND test_config_loading)
 
+add_executable(test_config_from_json test_config_from_json.cpp)
+target_link_libraries(test_config_from_json PRIVATE autogithubpullmerge_lib)
+add_test(NAME config_from_json_test COMMAND test_config_from_json)
+
 add_executable(test_github_client_headers test_github_client_headers.cpp)
 target_link_libraries(test_github_client_headers
                       PRIVATE autogithubpullmerge_lib)

--- a/tests/test_config_from_json.cpp
+++ b/tests/test_config_from_json.cpp
@@ -1,0 +1,25 @@
+#include "config.hpp"
+#include <cassert>
+#include <chrono>
+#include <nlohmann/json.hpp>
+
+int main() {
+  nlohmann::json j;
+  j["verbose"] = true;
+  j["poll_interval"] = 12;
+  j["max_request_rate"] = 42;
+  j["log_level"] = "debug";
+  j["include_repos"] = {"a", "b"};
+  j["pr_since"] = "5m";
+
+  agpm::Config cfg = agpm::Config::from_json(j);
+
+  assert(cfg.verbose());
+  assert(cfg.poll_interval() == 12);
+  assert(cfg.max_request_rate() == 42);
+  assert(cfg.log_level() == "debug");
+  assert(cfg.include_repos().size() == 2);
+  assert(cfg.pr_since() == std::chrono::minutes(5));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add Config::from_json and process both YAML and JSON through it
- test configuration loading with a direct JSON object

## Testing
- `./test_config_from_json`
- `./test_config`
- `./test_config_loading`
- `./test_config_manager`


------
https://chatgpt.com/codex/tasks/task_e_68a26e3991e8832595811ff5258bf01e