### PR TITLE
fix: make mac install script executable

### DIFF
--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -7,6 +7,10 @@ echo "✨ Beginning macOS dependency installation..."
 
 # Install required packages
 echo "🍎 Updating Homebrew and installing requirements..."
+if ! command -v brew >/dev/null 2>&1; then
+        echo "❌ Homebrew is not installed. Please install it from https://brew.sh and rerun this script."
+        exit 1
+fi
 brew update
 brew install cmake git curl libpsl sqlite3 spdlog ncurses pkg-config
 


### PR DESCRIPTION
## Summary
- fix: make mac install script executable
- fix: fail fast with a helpful message when Homebrew is missing

## Testing
- `bash -n scripts/install_mac.sh`
- `scripts/install_mac.sh` *(fails: Homebrew is not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68a2f33f76148325ba33807f8a71bb1d