### PR TITLE
feat: unify json-based config loading

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -189,6 +189,9 @@ public:
   /// Build configuration from a JSON object.
   static Config from_json(const nlohmann::json &j);
 
+  /// Populate this configuration from a JSON object.
+  void load_json(const nlohmann::json &j);
+
 private:
   bool verbose_ = false;
   int poll_interval_ = 0;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -59,86 +59,90 @@ nlohmann::json yaml_to_json(const YAML::Node &node) {
 
 } // namespace
 
-Config Config::from_json(const nlohmann::json &j) {
-  Config cfg;
+void Config::load_json(const nlohmann::json &j) {
   if (j.contains("verbose")) {
-    cfg.set_verbose(j["verbose"].get<bool>());
+    set_verbose(j["verbose"].get<bool>());
   }
   if (j.contains("poll_interval")) {
-    cfg.set_poll_interval(j["poll_interval"].get<int>());
+    set_poll_interval(j["poll_interval"].get<int>());
   }
   if (j.contains("max_request_rate")) {
-    cfg.set_max_request_rate(j["max_request_rate"].get<int>());
+    set_max_request_rate(j["max_request_rate"].get<int>());
   }
   if (j.contains("http_timeout")) {
-    cfg.set_http_timeout(j["http_timeout"].get<int>());
+    set_http_timeout(j["http_timeout"].get<int>());
   }
   if (j.contains("http_retries")) {
-    cfg.set_http_retries(j["http_retries"].get<int>());
+    set_http_retries(j["http_retries"].get<int>());
   }
   if (j.contains("log_level")) {
-    cfg.set_log_level(j["log_level"].get<std::string>());
+    set_log_level(j["log_level"].get<std::string>());
   }
   if (j.contains("log_pattern")) {
-    cfg.set_log_pattern(j["log_pattern"].get<std::string>());
+    set_log_pattern(j["log_pattern"].get<std::string>());
   }
   if (j.contains("log_file")) {
-    cfg.set_log_file(j["log_file"].get<std::string>());
+    set_log_file(j["log_file"].get<std::string>());
   }
   if (j.contains("include_repos")) {
-    cfg.set_include_repos(j["include_repos"].get<std::vector<std::string>>());
+    set_include_repos(j["include_repos"].get<std::vector<std::string>>());
   }
   if (j.contains("exclude_repos")) {
-    cfg.set_exclude_repos(j["exclude_repos"].get<std::vector<std::string>>());
+    set_exclude_repos(j["exclude_repos"].get<std::vector<std::string>>());
   }
   if (j.contains("include_merged")) {
-    cfg.set_include_merged(j["include_merged"].get<bool>());
+    set_include_merged(j["include_merged"].get<bool>());
   }
   if (j.contains("api_keys")) {
-    cfg.set_api_keys(j["api_keys"].get<std::vector<std::string>>());
+    set_api_keys(j["api_keys"].get<std::vector<std::string>>());
   }
   if (j.contains("api_key_from_stream")) {
-    cfg.set_api_key_from_stream(j["api_key_from_stream"].get<bool>());
+    set_api_key_from_stream(j["api_key_from_stream"].get<bool>());
   }
   if (j.contains("api_key_url")) {
-    cfg.set_api_key_url(j["api_key_url"].get<std::string>());
+    set_api_key_url(j["api_key_url"].get<std::string>());
   }
   if (j.contains("api_key_url_user")) {
-    cfg.set_api_key_url_user(j["api_key_url_user"].get<std::string>());
+    set_api_key_url_user(j["api_key_url_user"].get<std::string>());
   }
   if (j.contains("api_key_url_password")) {
-    cfg.set_api_key_url_password(j["api_key_url_password"].get<std::string>());
+    set_api_key_url_password(j["api_key_url_password"].get<std::string>());
   }
   if (j.contains("api_key_file")) {
-    cfg.set_api_key_file(j["api_key_file"].get<std::string>());
+    set_api_key_file(j["api_key_file"].get<std::string>());
   }
   if (j.contains("history_db")) {
-    cfg.set_history_db(j["history_db"].get<std::string>());
+    set_history_db(j["history_db"].get<std::string>());
   }
   if (j.contains("only_poll_prs")) {
-    cfg.set_only_poll_prs(j["only_poll_prs"].get<bool>());
+    set_only_poll_prs(j["only_poll_prs"].get<bool>());
   }
   if (j.contains("only_poll_stray")) {
-    cfg.set_only_poll_stray(j["only_poll_stray"].get<bool>());
+    set_only_poll_stray(j["only_poll_stray"].get<bool>());
   }
   if (j.contains("reject_dirty")) {
-    cfg.set_reject_dirty(j["reject_dirty"].get<bool>());
+    set_reject_dirty(j["reject_dirty"].get<bool>());
   }
   if (j.contains("auto_merge")) {
-    cfg.set_auto_merge(j["auto_merge"].get<bool>());
+    set_auto_merge(j["auto_merge"].get<bool>());
   }
   if (j.contains("purge_prefix")) {
-    cfg.set_purge_prefix(j["purge_prefix"].get<std::string>());
+    set_purge_prefix(j["purge_prefix"].get<std::string>());
   }
   if (j.contains("pr_limit")) {
-    cfg.set_pr_limit(j["pr_limit"].get<int>());
+    set_pr_limit(j["pr_limit"].get<int>());
   }
   if (j.contains("pr_since")) {
-    cfg.set_pr_since(parse_duration(j["pr_since"].get<std::string>()));
+    set_pr_since(parse_duration(j["pr_since"].get<std::string>()));
   }
   if (j.contains("sort")) {
-    cfg.set_sort_mode(j["sort"].get<std::string>());
+    set_sort_mode(j["sort"].get<std::string>());
   }
+}
+
+Config Config::from_json(const nlohmann::json &j) {
+  Config cfg;
+  cfg.load_json(j);
   return cfg;
 }
 
@@ -148,21 +152,22 @@ Config Config::from_file(const std::string &path) {
     throw std::runtime_error("Unknown config file extension");
   }
   std::string ext = path.substr(pos + 1);
+  nlohmann::json j;
   if (ext == "yaml" || ext == "yml") {
     YAML::Node node = YAML::LoadFile(path);
-    nlohmann::json j = yaml_to_json(node);
-    return from_json(j);
-  }
-  if (ext == "json") {
+    j = yaml_to_json(node);
+  } else if (ext == "json") {
     std::ifstream f(path);
     if (!f) {
       throw std::runtime_error("Failed to open config file");
     }
-    nlohmann::json j;
     f >> j;
-    return from_json(j);
+  } else {
+    throw std::runtime_error("Unsupported config format");
   }
-  throw std::runtime_error("Unsupported config format");
+  Config cfg;
+  cfg.load_json(j);
+  return cfg;
 }
 
 } // namespace agpm

--- a/tests/test_config_from_json.cpp
+++ b/tests/test_config_from_json.cpp
@@ -11,6 +11,8 @@ int main() {
   j["log_level"] = "debug";
   j["include_repos"] = {"a", "b"};
   j["pr_since"] = "5m";
+  j["http_timeout"] = 40;
+  j["http_retries"] = 5;
 
   agpm::Config cfg = agpm::Config::from_json(j);
 
@@ -20,6 +22,8 @@ int main() {
   assert(cfg.log_level() == "debug");
   assert(cfg.include_repos().size() == 2);
   assert(cfg.pr_since() == std::chrono::minutes(5));
+  assert(cfg.http_timeout() == 40);
+  assert(cfg.http_retries() == 5);
 
   return 0;
 }

--- a/tests/test_config_loading.cpp
+++ b/tests/test_config_loading.cpp
@@ -9,6 +9,8 @@ int main() {
     f << "poll_interval: 10\n";
     f << "max_request_rate: 20\n";
     f << "log_level: debug\n";
+    f << "http_timeout: 60\n";
+    f << "http_retries: 7\n";
     f.close();
   }
   agpm::Config ycfg = agpm::Config::from_file("config.yaml");
@@ -16,6 +18,8 @@ int main() {
   assert(ycfg.poll_interval() == 10);
   assert(ycfg.max_request_rate() == 20);
   assert(ycfg.log_level() == "debug");
+  assert(ycfg.http_timeout() == 60);
+  assert(ycfg.http_retries() == 7);
 
   {
     std::ofstream f("config.json");
@@ -23,7 +27,9 @@ int main() {
     f << "\"verbose\":false,";
     f << "\"poll_interval\":5,";
     f << "\"max_request_rate\":15,";
-    f << "\"log_level\":\"warn\"";
+    f << "\"log_level\":\"warn\",";
+    f << "\"http_timeout\":50,";
+    f << "\"http_retries\":4";
     f << "}";
     f.close();
   }
@@ -32,6 +38,8 @@ int main() {
   assert(jcfg.poll_interval() == 5);
   assert(jcfg.max_request_rate() == 15);
   assert(jcfg.log_level() == "warn");
+  assert(jcfg.http_timeout() == 50);
+  assert(jcfg.http_retries() == 4);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- centralize config population through `Config::load_json`
- convert YAML to JSON and reuse loader for both formats
- test HTTP timeout and retry fields for YAML and JSON configs

## Testing
- `bash scripts/install_linux.sh` *(incomplete: building dependencies)*
- `bash scripts/build_linux.sh` *(fails: openssl requires Linux kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b6ecf714832581f436aa0c8317cb