### PR TITLE
feat(tui): display repository info

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -123,10 +123,10 @@ private:
 
 /// Representation of a GitHub pull request.
 struct PullRequest {
-  int number;
-  std::string title;
-  std::string owner{};
-  std::string repo{};
+  int number;          ///< PR number
+  std::string title;   ///< PR title
+  std::string owner{}; ///< Repository owner
+  std::string repo{};  ///< Repository name
 };
 
 /** Simple GitHub API client. */

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -348,11 +348,8 @@ GitHubClient::list_pull_requests(const std::string &owner,
       }
       if (since.count() > 0 && created < cutoff)
         continue;
-      PullRequest pr;
-      pr.number = item["number"].get<int>();
-      pr.title = item["title"].get<std::string>();
-      pr.owner = owner;
-      pr.repo = repo;
+      PullRequest pr{item["number"].get<int>(),
+                     item["title"].get<std::string>(), owner, repo};
       prs.push_back(pr);
       if (static_cast<int>(prs.size()) >= limit)
         break;

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -82,8 +82,8 @@ void Tui::draw() {
     if (i == selected_) {
       wattron(pr_win_, COLOR_PAIR(1));
     }
-    mvwprintw(pr_win_, 1 + i, 1, "#%d %s", prs_[i].number,
-              prs_[i].title.c_str());
+    mvwprintw(pr_win_, 1 + i, 1, "%s/%s #%d %s", prs_[i].owner.c_str(),
+              prs_[i].repo.c_str(), prs_[i].number, prs_[i].title.c_str());
     if (i == selected_) {
       wattroff(pr_win_, COLOR_PAIR(1));
     }

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -59,7 +59,9 @@ int main() {
   ui.draw();
   char buf[80];
   mvwinnstr(stdscr, 1, 1, buf, 79);
-  assert(std::string(buf).find("Test PR") != std::string::npos);
+  std::string line(buf);
+  assert(line.find("Test PR") != std::string::npos);
+  assert(line.find("o/r") != std::string::npos);
 
   int prev_get = raw->get_count;
   ui.handle_key('r');


### PR DESCRIPTION
## Summary
- document owner/repo fields on PullRequest and populate them when listing PRs
- render repository information in the TUI
- test that the TUI shows owner/repo

## Testing
- `scripts/build_linux.sh` *(fails: CMake was unable to find a build program corresponding to "Ninja"; vcpkg install error: building libev:x64-linux failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b6fe6f7883259d3c84353e0e2e85