### PR TITLE
feat: recreate TUI windows on resize

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -59,6 +59,8 @@ private:
   WINDOW *log_win_{nullptr};
   WINDOW *help_win_{nullptr};
   bool running_{false};
+  int last_h_{0}; ///< Cached terminal height for resize detection.
+  int last_w_{0}; ///< Cached terminal width for resize detection.
 };
 
 } // namespace agpm

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -60,7 +60,15 @@ void Tui::draw() {
   getmaxyx(stdscr, h, w);
   int log_h = h / 3;
   int help_w = w / 3;
-  if (!pr_win_) {
+  if (h != last_h_ || w != last_w_) {
+    last_h_ = h;
+    last_w_ = w;
+    if (pr_win_)
+      delwin(pr_win_);
+    if (log_win_)
+      delwin(log_win_);
+    if (help_win_)
+      delwin(help_win_);
     pr_win_ = newwin(h - log_h, w, 0, 0);
     log_win_ = newwin(log_h, w - help_w, h - log_h, 0);
     help_win_ = newwin(log_h, help_w, h - log_h, w - help_w);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,10 @@ add_executable(test_tui_log_limit test_tui_log_limit.cpp)
 target_link_libraries(test_tui_log_limit PRIVATE autogithubpullmerge_lib)
 add_test(NAME tui_log_limit_test COMMAND test_tui_log_limit)
 
+add_executable(test_tui_resize test_tui_resize.cpp)
+target_link_libraries(test_tui_resize PRIVATE autogithubpullmerge_lib)
+add_test(NAME tui_resize_test COMMAND test_tui_resize)
+
 add_executable(test_github_filter test_github_filter.cpp)
 target_link_libraries(test_github_filter PRIVATE autogithubpullmerge_lib)
 add_test(NAME github_filter_test COMMAND test_github_filter)

--- a/tests/test_tui_resize.cpp
+++ b/tests/test_tui_resize.cpp
@@ -1,0 +1,57 @@
+#include "github_poller.hpp"
+#define private public
+#include "tui.hpp"
+#undef private
+#include <cassert>
+#include <cstdlib>
+#include <memory>
+
+using namespace agpm;
+
+class MockHttpClient : public HttpClient {
+public:
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return {};
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return {};
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return {};
+  }
+};
+
+int main() {
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  auto mock = std::make_unique<MockHttpClient>();
+  GitHubClient client("token", std::move(mock));
+  GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
+  Tui ui(client, poller);
+  ui.init();
+
+  ui.update_prs({{1, "PR", "o", "r"}});
+  ui.draw();
+  WINDOW *before = ui.pr_win_;
+  int h, w;
+  getmaxyx(stdscr, h, w);
+  resize_term(h / 2, w / 2);
+  ui.draw();
+  assert(before != ui.pr_win_);
+  ui.cleanup();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- recreate TUI windows when terminal size changes
- cache previous dimensions to detect resizes
- test window recreation logic on resize

## Testing
- `bash scripts/install_linux.sh` *(failed: building libev:x64-linux failed)*
- `cmake -S . -B build` *(failed: vcpkg install failed and CMAKE_CXX_COMPILER not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c3569ec832586eaf8fb93dd8acc