### PR TITLE
feat: add stray branch polling and cleanup

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -177,6 +177,12 @@ public:
                           int pr_number);
 
   /**
+   * List branch names for a repository excluding the default branch.
+   */
+  std::vector<std::string> list_branches(const std::string &owner,
+                                         const std::string &repo);
+
+  /**
    * Delete branches whose associated pull request was closed or merged and
    * whose name begins with the given prefix.
    */

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -54,7 +54,20 @@ void GitHubPoller::poll() {
       }
     }
     if (!only_poll_prs_) {
-      // Placeholder for stray branch polling logic
+      auto branches = client_.list_branches(r.first, r.second);
+      std::vector<std::string> stray;
+      for (const auto &b : branches) {
+        if (purge_prefix_.empty() || b.rfind(purge_prefix_, 0) != 0) {
+          stray.push_back(b);
+        }
+      }
+      if (log_cb_) {
+        log_cb_(r.first + "/" + r.second +
+                " stray branches: " + std::to_string(stray.size()));
+      }
+      if (only_poll_stray_ && !purge_prefix_.empty()) {
+        client_.cleanup_branches(r.first, r.second, purge_prefix_);
+      }
       if (reject_dirty_) {
         client_.close_dirty_branches(r.first, r.second);
       }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,3 +113,7 @@ add_test(NAME auto_merge_test COMMAND test_auto_merge)
 add_executable(test_log test_log.cpp)
 target_link_libraries(test_log PRIVATE autogithubpullmerge_lib)
 add_test(NAME log_test COMMAND test_log)
+
+add_executable(test_poller_branch test_poller_branch.cpp)
+target_link_libraries(test_poller_branch PRIVATE autogithubpullmerge_lib)
+add_test(NAME poller_branch_test COMMAND test_poller_branch)

--- a/tests/test_poller_branch.cpp
+++ b/tests/test_poller_branch.cpp
@@ -1,0 +1,116 @@
+#include "github_poller.hpp"
+#include <cassert>
+#include <string>
+#include <unordered_set>
+
+using namespace agpm;
+
+class BranchListClient : public HttpClient {
+public:
+  int branch_get_count = 0;
+  std::string base = "https://api.github.com/repos/me/repo";
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    if (url == base)
+      return "{\"default_branch\":\"main\"}";
+    if (url == base + "/branches") {
+      branch_get_count++;
+      return "[{\"name\":\"main\"},{\"name\":\"feature\"}]";
+    }
+    return "[]";
+  }
+  HttpResponse
+  get_with_headers(const std::string &url,
+                   const std::vector<std::string> &headers) override {
+    HttpResponse res;
+    res.status_code = 200;
+    res.body = get(url, headers);
+    return res;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "";
+  }
+};
+
+class BranchCleanupClient : public HttpClient {
+public:
+  std::string base = "https://api.github.com/repos/me/repo";
+  std::unordered_set<std::string> deleted;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    if (url == base)
+      return "{\"default_branch\":\"main\"}";
+    if (url == base + "/branches")
+      return "[{\"name\":\"main\"},{\"name\":\"tmp/"
+             "purge\"},{\"name\":\"feature\"}]";
+    if (url == base + "/compare/main...feature")
+      return "{\"status\":\"ahead\",\"ahead_by\":1}";
+    if (url == base + "/compare/main...tmp/purge")
+      return "{\"status\":\"identical\"}";
+    if (url == base + "/pulls?state=closed")
+      return "[{\"head\":{\"ref\":\"tmp/purge\"}}]";
+    return "[]";
+  }
+  HttpResponse
+  get_with_headers(const std::string &url,
+                   const std::vector<std::string> &headers) override {
+    HttpResponse res;
+    res.status_code = 200;
+    res.body = get(url, headers);
+    return res;
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    deleted.insert(url);
+    return "";
+  }
+};
+
+int main() {
+  // Detect stray branches without cleanup
+  {
+    auto http = std::make_unique<BranchListClient>();
+    BranchListClient *raw = http.get();
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    GitHubPoller poller(client, {{"me", "repo"}}, 1000, 60, false, true);
+    std::string msg;
+    poller.set_log_callback([&](const std::string &m) { msg = m; });
+    poller.poll_now();
+    assert(raw->branch_get_count == 1);
+    assert(msg.find("stray branches: 1") != std::string::npos);
+  }
+
+  // Cleanup branches and close dirty ones
+  {
+    auto http = std::make_unique<BranchCleanupClient>();
+    BranchCleanupClient *raw = http.get();
+    GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+    GitHubPoller poller(client, {{"me", "repo"}}, 1000, 60, false, true, true,
+                        "tmp/");
+    poller.poll_now();
+    assert(raw->deleted.count(raw->base + "/git/refs/heads/feature") == 1);
+    assert(raw->deleted.count(raw->base + "/git/refs/heads/tmp/purge") == 1);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- add stray branch polling logic and cleanup to GitHubPoller
- expose list_branches in GitHubClient
- cover branch polling and cleanup behaviors with new tests

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set / long dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68a472bf1e708325b94f0ab75a0fd526