### PR TITLE
fix: add purge-only configuration option

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -147,6 +147,12 @@ public:
   /// Set only poll stray flag.
   void set_only_poll_stray(bool v) { only_poll_stray_ = v; }
 
+  /// Only purge stray branches without polling PRs.
+  bool purge_only() const { return purge_only_; }
+
+  /// Set purge only flag.
+  void set_purge_only(bool v) { purge_only_ = v; }
+
   /// Auto reject dirty branches.
   bool reject_dirty() const { return reject_dirty_; }
 
@@ -211,6 +217,7 @@ private:
   std::string history_db_ = "history.db";
   bool only_poll_prs_ = false;
   bool only_poll_stray_ = false;
+  bool purge_only_ = false;
   bool reject_dirty_ = false;
   bool auto_merge_ = false;
   std::string purge_prefix_;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -120,6 +120,9 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("only_poll_stray")) {
     set_only_poll_stray(j["only_poll_stray"].get<bool>());
   }
+  if (j.contains("purge_only")) {
+    set_purge_only(j["purge_only"].get<bool>());
+  }
   if (j.contains("reject_dirty")) {
     set_reject_dirty(j["reject_dirty"].get<bool>());
   }


### PR DESCRIPTION
## Summary
- add `purge_only` field to Config with accessors and parsing
- support `purge_only` in JSON configuration

## Testing
- `cmake -S . -B build` *(fails: Vcpkg toolchain file not found)*
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a0677250832586d833fa85387c10