### PR TITLE
fix: add purge-only config option

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -159,6 +159,12 @@ public:
   /// Set auto merge flag.
   void set_auto_merge(bool v) { auto_merge_ = v; }
 
+  /// Only purge branches without polling pull requests.
+  bool purge_only() const { return purge_only_; }
+
+  /// Set only purge branches flag.
+  void set_purge_only(bool v) { purge_only_ = v; }
+
   /// Prefix of branches to purge after merge.
   const std::string &purge_prefix() const { return purge_prefix_; }
 
@@ -213,6 +219,7 @@ private:
   bool only_poll_stray_ = false;
   bool reject_dirty_ = false;
   bool auto_merge_ = false;
+  bool purge_only_ = false;
   std::string purge_prefix_;
   int pr_limit_ = 50;
   std::chrono::seconds pr_since_{0};

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -126,6 +126,9 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("auto_merge")) {
     set_auto_merge(j["auto_merge"].get<bool>());
   }
+  if (j.contains("purge_only")) {
+    set_purge_only(j["purge_only"].get<bool>());
+  }
   if (j.contains("purge_prefix")) {
     set_purge_prefix(j["purge_prefix"].get<std::string>());
   }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -19,6 +19,7 @@ int main() {
     f << "only_poll_prs: true\n";
     f << "reject_dirty: true\n";
     f << "auto_merge: true\n";
+    f << "purge_only: true\n";
     f << "purge_prefix: tmp/\n";
     f << "pr_limit: 25\n";
     f << "pr_since: 2h\n";
@@ -40,6 +41,7 @@ int main() {
   assert(yaml_cfg.only_poll_prs());
   assert(yaml_cfg.reject_dirty());
   assert(yaml_cfg.auto_merge());
+  assert(yaml_cfg.purge_only());
   assert(yaml_cfg.purge_prefix() == "tmp/");
   assert(yaml_cfg.pr_limit() == 25);
   assert(yaml_cfg.pr_since() == std::chrono::hours(2));
@@ -58,6 +60,7 @@ int main() {
     f << "\"api_keys\":[\"k1\"],";
     f << "\"history_db\":\"db.sqlite\",";
     f << "\"only_poll_stray\":true,";
+    f << "\"purge_only\":true,";
     f << "\"purge_prefix\":\"test/\",";
     f << "\"pr_limit\":30,";
     f << "\"pr_since\":\"15m\",";
@@ -77,6 +80,7 @@ int main() {
   assert(json_cfg.api_keys().size() == 1);
   assert(json_cfg.history_db() == "db.sqlite");
   assert(json_cfg.only_poll_stray());
+  assert(json_cfg.purge_only());
   assert(json_cfg.purge_prefix() == "test/");
   assert(json_cfg.pr_limit() == 30);
   assert(json_cfg.pr_since() == std::chrono::minutes(15));


### PR DESCRIPTION
## Summary
- add purge_only flag to Config
- parse purge_only from config files
- test purge_only in YAML and JSON configs

## Testing
- `g++ -std=c++20 -Iinclude tests/test_config.cpp src/config.cpp src/util/duration.cpp -lyaml-cpp -o test_config`
- `./test_config`
- `g++ -std=c++20 -Iinclude tests/test_cli.cpp src/cli.cpp src/util/duration.cpp -lyaml-cpp -lcurl -o test_cli`
- `./test_cli < /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68a4a3b74524832598b57f139c4aefe1