### PR TITLE
chore: ensure install scripts prepare full toolchains

### DIFF
--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=util.sh
 . "${SCRIPT_DIR}/util.sh"
 
-ensure_tool make
+ensure_tool ninja
 ensure_tool cmake
 
 if [[ -z "${VCPKG_ROOT}" ]]; then

--- a/scripts/build_mac.sh
+++ b/scripts/build_mac.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=util.sh
 . "${SCRIPT_DIR}/util.sh"
 
-ensure_tool make
+ensure_tool ninja
 ensure_tool cmake
 
 if [[ -z "${VCPKG_ROOT}" ]]; then

--- a/scripts/install_linux.sh
+++ b/scripts/install_linux.sh
@@ -8,7 +8,7 @@ echo "✨ Beginning Linux dependency installation..."
 # Install essential build tools
 echo "🔧 Updating package lists and installing build essentials..."
 sudo apt-get update
-sudo apt-get install -y build-essential cmake git curl
+sudo apt-get install -y build-essential cmake git curl pkg-config ninja-build libpsl-dev libsqlite3-dev libspdlog-dev libncurses-dev
 
 # Clone vcpkg if VCPKG_ROOT is not set
 echo "📦 Ensuring vcpkg is available..."
@@ -18,22 +18,28 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
 	export VCPKG_ROOT="${SCRIPT_DIR}/../vcpkg"
 fi
 
-# Bootstrap vcpkg if needed
 echo "🚀 Bootstrapping vcpkg..."
 if [[ ! -f "${VCPKG_ROOT}/vcpkg" ]]; then
 	"${VCPKG_ROOT}/bootstrap-vcpkg.sh"
 fi
 
-# Install dependencies from vcpkg.json
-echo "📚 Installing project dependencies via vcpkg..."
-"${VCPKG_ROOT}/vcpkg" install
+echo "🎯 Setting up default vcpkg triplet..."
+if [[ -z "${VCPKG_DEFAULT_TRIPLET}" ]]; then
+	export VCPKG_DEFAULT_TRIPLET="x64-linux"
+fi
 
-# Persist environment variables
-echo "📝 Persisting VCPKG_ROOT and updating PATH..."
+echo "📚 Installing project dependencies via vcpkg..."
+"${VCPKG_ROOT}/vcpkg" install --triplet "${VCPKG_DEFAULT_TRIPLET}"
+"${VCPKG_ROOT}/vcpkg" integrate install
+
+echo "📝 Persisting VCPKG_ROOT, VCPKG_DEFAULT_TRIPLET and updating PATH..."
 PROFILE_FILE="$HOME/.bashrc"
 if ! grep -q "VCPKG_ROOT" "${PROFILE_FILE}"; then
-	echo "export VCPKG_ROOT=\"${VCPKG_ROOT}\"" >>"${PROFILE_FILE}"
-	echo "export PATH=\"\$VCPKG_ROOT:\$PATH\"" >>"${PROFILE_FILE}"
+	{
+		echo "export VCPKG_ROOT=\"${VCPKG_ROOT}\""
+		echo "export VCPKG_DEFAULT_TRIPLET=\"${VCPKG_DEFAULT_TRIPLET}\""
+		echo "export PATH=\"\$VCPKG_ROOT:\$PATH\""
+	} >>"${PROFILE_FILE}"
 fi
 
 echo "✅ Installation completed. Please restart your shell for changes to take effect."

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -8,11 +8,11 @@ echo "✨ Beginning macOS dependency installation..."
 # Install required packages
 echo "🍎 Updating Homebrew and installing requirements..."
 if ! command -v brew >/dev/null 2>&1; then
-        echo "❌ Homebrew is not installed. Please install it from https://brew.sh and rerun this script."
-        exit 1
+	echo "❌ Homebrew is not installed. Please install it from https://brew.sh and rerun this script."
+	exit 1
 fi
 brew update
-brew install cmake git curl libpsl sqlite3 spdlog ncurses pkg-config
+brew install cmake git curl libpsl sqlite3 spdlog ncurses pkg-config ninja gcc
 
 # Clone vcpkg if VCPKG_ROOT is not set
 echo "📦 Ensuring vcpkg is available..."
@@ -22,22 +22,28 @@ if [[ -z "${VCPKG_ROOT}" ]]; then
 	export VCPKG_ROOT="${SCRIPT_DIR}/../vcpkg"
 fi
 
-# Bootstrap vcpkg if needed
 echo "🚀 Bootstrapping vcpkg..."
 if [[ ! -f "${VCPKG_ROOT}/vcpkg" ]]; then
 	"${VCPKG_ROOT}/bootstrap-vcpkg.sh"
 fi
 
-# Install dependencies from vcpkg.json
-echo "📚 Installing project dependencies via vcpkg..."
-"${VCPKG_ROOT}/vcpkg" install
+echo "🎯 Setting up default vcpkg triplet..."
+if [[ -z "${VCPKG_DEFAULT_TRIPLET}" ]]; then
+	export VCPKG_DEFAULT_TRIPLET="x64-osx"
+fi
 
-# Persist environment variables
-echo "📝 Persisting VCPKG_ROOT and updating PATH..."
+echo "📚 Installing project dependencies via vcpkg..."
+"${VCPKG_ROOT}/vcpkg" install --triplet "${VCPKG_DEFAULT_TRIPLET}"
+"${VCPKG_ROOT}/vcpkg" integrate install
+
+echo "📝 Persisting VCPKG_ROOT, VCPKG_DEFAULT_TRIPLET and updating PATH..."
 PROFILE_FILE="$HOME/.zprofile"
 if ! grep -q "VCPKG_ROOT" "${PROFILE_FILE}" 2>/dev/null; then
-	echo "export VCPKG_ROOT=\"${VCPKG_ROOT}\"" >>"${PROFILE_FILE}"
-	echo "export PATH=\"\$VCPKG_ROOT:\$PATH\"" >>"${PROFILE_FILE}"
+	{
+		echo "export VCPKG_ROOT=\"${VCPKG_ROOT}\""
+		echo "export VCPKG_DEFAULT_TRIPLET=\"${VCPKG_DEFAULT_TRIPLET}\""
+		echo "export PATH=\"\$VCPKG_ROOT:\$PATH\""
+	} >>"${PROFILE_FILE}"
 fi
 
 echo "✅ Installation completed. Please restart your shell for changes to take effect."


### PR DESCRIPTION
## Summary
- install all required build tools on Linux and macOS
- set default vcpkg triplets and run vcpkg integration
- build scripts now require Ninja instead of make

## Testing
- `shfmt -w scripts/install_linux.sh scripts/install_mac.sh scripts/build_linux.sh scripts/build_mac.sh`
- `shellcheck scripts/install_linux.sh scripts/install_mac.sh scripts/build_linux.sh scripts/build_mac.sh`
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bfff2ab4832591fd5de5e8a2efc8