### PR TITLE
fix: remove duplicate purge-only configuration

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -189,12 +189,6 @@ public:
   /// Set auto merge flag.
   void set_auto_merge(bool v) { auto_merge_ = v; }
 
-  /// Only purge branches without polling pull requests.
-  bool purge_only() const { return purge_only_; }
-
-  /// Set only purge branches flag.
-  void set_purge_only(bool v) { purge_only_ = v; }
-
   /// Prefix of branches to purge after merge.
   const std::string &purge_prefix() const { return purge_prefix_; }
 
@@ -250,7 +244,6 @@ private:
   bool purge_only_ = false;
   bool reject_dirty_ = false;
   bool auto_merge_ = false;
-  bool purge_only_ = false;
   std::string purge_prefix_;
   int pr_limit_ = 50;
   std::chrono::seconds pr_since_{0};

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -141,9 +141,6 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("auto_merge")) {
     set_auto_merge(j["auto_merge"].get<bool>());
   }
-  if (j.contains("purge_only")) {
-    set_purge_only(j["purge_only"].get<bool>());
-  }
   if (j.contains("purge_prefix")) {
     set_purge_prefix(j["purge_prefix"].get<std::string>());
   }


### PR DESCRIPTION
## Summary
- remove duplicate `purge_only` declarations and member to fix build redefinition errors
- ensure configuration loader only handles `purge_only` once

## Testing
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b99081c083258893300c67fa7994