### PR TITLE
feat: report CLI parse errors and cancellations

### DIFF
--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -62,6 +62,9 @@ The following options perform destructive actions and require confirmation
   closed or merged.
 - `--purge-only` - skip pull request polling and only run branch cleanup.
 
+Declining the confirmation prompt aborts the command and returns a non-zero
+exit code.
+
 ## Stray Branch Management
 
 ### Isolated Stray-Branch Purge Mode

--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -50,6 +50,8 @@ struct CliOptions {
  * @param argc Number of arguments
  * @param argv Argument values
  * @return Parsed options structure
+ * @throws std::runtime_error on parse errors or when destructive
+ *         operations are cancelled by the user
  */
 CliOptions parse_cli(int argc, char **argv);
 

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -3,12 +3,18 @@
 #include "config.hpp"
 #include "log.hpp"
 #include <cstdlib>
+#include <exception>
 #include <spdlog/spdlog.h>
 
 namespace agpm {
 
 int App::run(int argc, char **argv) {
-  options_ = parse_cli(argc, argv);
+  try {
+    options_ = parse_cli(argc, argv);
+  } catch (const std::exception &e) {
+    spdlog::error("{}", e.what());
+    return 1;
+  }
   include_repos_ = options_.include_repos;
   exclude_repos_ = options_.exclude_repos;
   if (!options_.config_file.empty()) {

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -254,7 +254,7 @@ CliOptions parse_cli(int argc, char **argv) {
   try {
     app.parse(argc, argv);
   } catch (const CLI::ParseError &e) {
-    exit(app.exit(e));
+    throw std::runtime_error(e.what());
   }
   if (!options.api_key_file.empty()) {
     auto tokens = load_tokens_from_file(options.api_key_file);
@@ -293,8 +293,7 @@ CliOptions parse_cli(int argc, char **argv) {
     std::string resp;
     std::getline(std::cin, resp);
     if (!(resp == "y" || resp == "Y" || resp == "yes" || resp == "YES")) {
-      std::cout << "Aborted.\n";
-      std::exit(1);
+      throw std::runtime_error("Operation cancelled by user");
     }
   }
   return options;

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -2,7 +2,9 @@
 #include <cassert>
 #include <chrono>
 #include <cstdlib>
+#include <exception>
 #include <fstream>
+#include <sstream>
 
 int main() {
   char prog[] = "prog";
@@ -231,6 +233,34 @@ int main() {
   agpm::CliOptions opts_max = agpm::parse_cli(5, argv_max);
   assert(opts_max.max_download == 5000);
   assert(opts_max.max_upload == 6000);
+
+  {
+    char bad[] = "--unknown";
+    char *argv_bad[] = {prog, bad};
+    bool threw = false;
+    try {
+      agpm::parse_cli(2, argv_bad);
+    } catch (const std::exception &) {
+      threw = true;
+    }
+    assert(threw);
+  }
+
+  {
+    std::istringstream input("n\n");
+    auto *cinbuf = std::cin.rdbuf();
+    std::cin.rdbuf(input.rdbuf());
+    char auto_merge_flag2[] = "--auto-merge";
+    char *argv_cancel[] = {prog, auto_merge_flag2};
+    bool threw = false;
+    try {
+      agpm::parse_cli(2, argv_cancel);
+    } catch (const std::exception &) {
+      threw = true;
+    }
+    std::cin.rdbuf(cinbuf);
+    assert(threw);
+  }
 
   return 0;
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -7,7 +7,9 @@
 #include <atomic>
 #include <cassert>
 #include <cstdlib>
+#include <exception>
 #include <fstream>
+#include <sstream>
 #include <thread>
 #include <vector>
 
@@ -134,6 +136,26 @@ int main() {
     json.close();
     agpm::Config cfg = agpm::Config::from_file("test_config.json");
     assert(cfg.verbose());
+  }
+
+  {
+    agpm::App bad_app;
+    char prog_err[] = "tests";
+    char unknown[] = "--unknown";
+    char *args_err[] = {prog_err, unknown};
+    assert(bad_app.run(2, args_err) != 0);
+  }
+
+  {
+    agpm::App cancel_app;
+    std::istringstream input("n\n");
+    auto *cinbuf = std::cin.rdbuf();
+    std::cin.rdbuf(input.rdbuf());
+    char prog_err2[] = "tests";
+    char auto_merge_flag2[] = "--auto-merge";
+    char *cancel_args[] = {prog_err2, auto_merge_flag2};
+    assert(cancel_app.run(2, cancel_args) != 0);
+    std::cin.rdbuf(cinbuf);
   }
   return 0;
 }


### PR DESCRIPTION
## Summary
- return CLI parse failures and canceled destructive options as exceptions
- handle CLI errors in `App::run`
- document new behavior and test edge cases

## Testing
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a72572ac3083258b15f926792e682c