### PR TITLE
fix: remove unused libev dependency

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,6 @@
     "cli11",
     "curl",
     "fmt",
-    "libev",
     {
       "name": "ncurses",
       "platform": "!windows"


### PR DESCRIPTION
## Summary
- drop libev from vcpkg dependencies to prevent build failures

## Testing
- `bash scripts/install_linux.sh`
- `VCPKG_ROOT=$PWD/vcpkg cmake --preset vcpkg`


------
https://chatgpt.com/codex/tasks/task_e_68a735d283e48325bf6b70619cb6a1d7