### PR TITLE
fix: ensure CurlSlist default construction

### DIFF
--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -14,6 +14,7 @@ namespace agpm {
 
 struct CurlSlist {
   curl_slist *list{nullptr};
+  CurlSlist() = default;
   ~CurlSlist() { curl_slist_free_all(list); }
   void append(const std::string &s) {
     list = curl_slist_append(list, s.c_str());

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <exception>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 
 TEST_CASE("test cli") {

--- a/tests/test_cli_tokens.cpp
+++ b/tests/test_cli_tokens.cpp
@@ -1,6 +1,7 @@
 #include "cli.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 
 TEST_CASE("test cli tokens") {

--- a/tests/test_github_client_delay.cpp
+++ b/tests/test_github_client_delay.cpp
@@ -54,7 +54,7 @@ TEST_CASE("test github client delay") {
   try {
     CurlHttpClient real;
     real.get("https://nonexistent.invalid", {});
-    REQUIRE(false && "Expected exception");
+    FAIL("Expected exception");
   } catch (const std::exception &e) {
     std::string msg = e.what();
     REQUIRE(msg.find("nonexistent.invalid") != std::string::npos);

--- a/tests/test_github_client_headers.cpp
+++ b/tests/test_github_client_headers.cpp
@@ -47,7 +47,8 @@ TEST_CASE("test github client headers") {
     if (h == "User-Agent: autogithubpullmerge")
       found_agent = true;
   }
-  REQUIRE(found_auth && found_agent);
+  REQUIRE(found_auth);
+  REQUIRE(found_agent);
 
   auto http2 = std::make_unique<HeaderHttpClient>();
   http2->response = "{\"merged\":true}";
@@ -63,5 +64,6 @@ TEST_CASE("test github client headers") {
     if (h == "User-Agent: autogithubpullmerge")
       found_agent = true;
   }
-  REQUIRE(found_auth && found_agent);
+  REQUIRE(found_auth);
+  REQUIRE(found_agent);
 }

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <exception>
 #include <fstream>
+#include <iostream>
 #include <sstream>
 #include <thread>
 #include <vector>


### PR DESCRIPTION
## Summary
- make CurlSlist RAII wrapper default constructible
- add missing `<iostream>` includes in CLI tests and clean up Catch2 assertions

## Testing
- `bash scripts/build_linux.sh` *(fails: agpm_tests segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68a74106eed083258b4adfcecafa4e26