### PR TITLE
feat: support combined duration units

### DIFF
--- a/include/util/duration.hpp
+++ b/include/util/duration.hpp
@@ -7,12 +7,13 @@
 namespace agpm {
 
 /**
- * Parse a human-readable duration string (e.g. "10s", "5m", "2h", "3d", "1w")
- * into a std::chrono::seconds value.
+ * Parse a human-readable duration string (e.g. "10s", "5m", "2h", "3d",
+ * "1w", "1h30m") into a std::chrono::seconds value. Multiple units can be
+ * combined and a pure number is interpreted as seconds.
  *
  * @param str Duration string; empty string returns zero seconds.
  * @return Parsed duration in seconds.
- * @throws std::runtime_error if an invalid suffix is provided.
+ * @throws std::runtime_error if an invalid format or suffix is provided.
  */
 std::chrono::seconds parse_duration(const std::string &str);
 

--- a/src/util/duration.cpp
+++ b/src/util/duration.cpp
@@ -6,30 +6,59 @@
 namespace agpm {
 
 std::chrono::seconds parse_duration(const std::string &str) {
-  if (str.empty())
+  if (str.empty()) {
     return std::chrono::seconds{0};
-  char unit = str.back();
-  std::string num = str;
-  if (!std::isdigit(static_cast<unsigned char>(unit))) {
-    num.pop_back();
-  } else {
-    unit = 's';
   }
-  long value = std::stol(num);
-  switch (std::tolower(static_cast<unsigned char>(unit))) {
-  case 's':
-    return std::chrono::seconds{value};
-  case 'm':
-    return std::chrono::seconds{value * 60};
-  case 'h':
-    return std::chrono::seconds{value * 3600};
-  case 'd':
-    return std::chrono::seconds{value * 86400};
-  case 'w':
-    return std::chrono::seconds{value * 604800};
-  default:
-    throw std::runtime_error("Invalid duration suffix");
+
+  using namespace std::chrono;
+  long total = 0;
+  std::size_t i = 0;
+  bool has_unit = false;
+
+  while (i < str.size()) {
+    if (!std::isdigit(static_cast<unsigned char>(str[i]))) {
+      throw std::runtime_error("Invalid duration string");
+    }
+
+    long value = 0;
+    while (i < str.size() && std::isdigit(static_cast<unsigned char>(str[i]))) {
+      value = value * 10 + (str[i] - '0');
+      ++i;
+    }
+
+    if (i == str.size()) {
+      if (has_unit) {
+        throw std::runtime_error("Missing unit in duration");
+      }
+      total += value; // plain seconds
+      break;
+    }
+
+    char unit = std::tolower(static_cast<unsigned char>(str[i]));
+    ++i;
+    switch (unit) {
+    case 's':
+      total += value;
+      break;
+    case 'm':
+      total += value * 60;
+      break;
+    case 'h':
+      total += value * 3600;
+      break;
+    case 'd':
+      total += value * 86400;
+      break;
+    case 'w':
+      total += value * 604800;
+      break;
+    default:
+      throw std::runtime_error("Invalid duration suffix");
+    }
+    has_unit = true;
   }
+
+  return seconds{total};
 }
 
 } // namespace agpm

--- a/tests/test_duration.cpp
+++ b/tests/test_duration.cpp
@@ -1,0 +1,21 @@
+#include "util/duration.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <chrono>
+
+using namespace agpm;
+using namespace std::chrono;
+
+TEST_CASE("parse_duration supports combined units") {
+  CHECK(parse_duration("1h30m") == seconds{3600 + 30 * 60});
+  CHECK(parse_duration("2d3h4m5s") ==
+        seconds{2 * 86400 + 3 * 3600 + 4 * 60 + 5});
+  CHECK(parse_duration("10") == seconds{10});
+  CHECK(parse_duration("") == seconds{0});
+}
+
+TEST_CASE("parse_duration rejects invalid strings") {
+  CHECK_THROWS_AS(parse_duration("1h30"), std::runtime_error);
+  CHECK_THROWS_AS(parse_duration("10m5"), std::runtime_error);
+  CHECK_THROWS_AS(parse_duration("abc"), std::runtime_error);
+  CHECK_THROWS_AS(parse_duration("1.5h"), std::runtime_error);
+}


### PR DESCRIPTION
## Summary
- allow parsing durations with combined units like `1h30m`
- reject malformed duration strings
- test various valid and invalid duration combinations

## Testing
- `./scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a74edac3808325bfd5fce7183f4b61