### PR TITLE
fix: address compiler warnings

### DIFF
--- a/include/sort.hpp
+++ b/include/sort.hpp
@@ -27,8 +27,10 @@ inline bool alphanum_less(const std::string &a, const std::string &b) {
       i = i1;
       j = j1;
     } else {
-      char c1 = std::tolower(static_cast<unsigned char>(a[i]));
-      char c2 = std::tolower(static_cast<unsigned char>(b[j]));
+      char c1 =
+          static_cast<char>(std::tolower(static_cast<unsigned char>(a[i])));
+      char c2 =
+          static_cast<char>(std::tolower(static_cast<unsigned char>(b[j])));
       if (c1 != c2)
         return c1 < c2;
       ++i;


### PR DESCRIPTION
## Summary
- prevent narrowing conversions in alphanumeric sorting helper
- use secure cross-platform environment variable retrieval

## Testing
- `cmake -S . -B build` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8578891248325804c6d1e67496b0e