### PR TITLE
feat: auto list accessible repositories

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -8,6 +8,7 @@
 #include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace agpm {
@@ -174,6 +175,13 @@ public:
 
   /// Set minimum delay between HTTP requests in milliseconds.
   void set_delay_ms(int delay_ms);
+
+  /**
+   * List repositories accessible to the authenticated user.
+   *
+   * @return List of repository owner/name pairs
+   */
+  std::vector<std::pair<std::string, std::string>> list_repositories();
 
   /**
    * List pull requests for a repository.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,9 @@ int main(int argc, char **argv) {
         repos.emplace_back(r.substr(0, pos), r.substr(pos + 1));
       }
     }
+    if (repos.empty()) {
+      repos = client.list_repositories();
+    }
 
     std::string history_db =
         !opts.history_db.empty() ? opts.history_db : cfg.history_db();

--- a/tests/test_repo_listing.cpp
+++ b/tests/test_repo_listing.cpp
@@ -1,0 +1,54 @@
+#include "github_client.hpp"
+#include "github_poller.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <utility>
+#include <vector>
+
+using namespace agpm;
+
+class RepoHttpClient : public HttpClient {
+public:
+  int repo_calls = 0;
+  int pr_calls = 0;
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    if (url.find("/user/repos") != std::string::npos) {
+      ++repo_calls;
+      return "[{\"name\":\"repo\",\"owner\":{\"login\":\"me\"}}]";
+    }
+    if (url.find("/repos/me/repo/pulls") != std::string::npos) {
+      ++pr_calls;
+      return "[]";
+    }
+    return "[]";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "";
+  }
+};
+
+TEST_CASE("list repositories and poll when none included") {
+  auto http = std::make_unique<RepoHttpClient>();
+  auto *raw = http.get();
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  std::vector<std::pair<std::string, std::string>> repos;
+  if (repos.empty())
+    repos = client.list_repositories();
+  REQUIRE(repos ==
+          std::vector<std::pair<std::string, std::string>>{{"me", "repo"}});
+  GitHubPoller poller(client, repos, 0, 60);
+  poller.poll_now();
+  REQUIRE(raw->repo_calls == 1);
+  REQUIRE(raw->pr_calls == 1);
+}


### PR DESCRIPTION
## Summary
- add GitHubClient::list_repositories to retrieve accessible repos
- populate repo list automatically when no repos explicitly included
- test that listing repos triggers polling

## Testing
- `./scripts/build_linux.sh` *(fails: [ERROR] VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a88c19bc408325bd1ecdcbf80c0b5b