### PR TITLE
Add configurable merge rules for pull requests

### DIFF
--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -42,6 +42,9 @@ struct CliOptions {
   bool only_poll_stray = false;          ///< Only poll stray branches
   bool reject_dirty = false;             ///< Auto close dirty branches
   bool auto_merge{false};                ///< Automatically merge pull requests
+  int required_approvals{0};             ///< Required approvals before merge
+  bool require_status_success{false};    ///< Require status checks to succeed
+  bool require_mergeable_state{false};   ///< Require PR to be mergeable
   std::string purge_prefix;              ///< Delete branches with this prefix
   bool purge_only = false; ///< Only purge branches, skip PR polling
   int pr_limit{50};        ///< Number of pull requests to fetch

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -209,6 +209,24 @@ public:
   /// Set auto merge flag.
   void set_auto_merge(bool v) { auto_merge_ = v; }
 
+  /// Required number of approvals before merging.
+  int required_approvals() const { return required_approvals_; }
+
+  /// Set required approvals.
+  void set_required_approvals(int n) { required_approvals_ = n; }
+
+  /// Require successful status checks before merging.
+  bool require_status_success() const { return require_status_success_; }
+
+  /// Set require status checks flag.
+  void set_require_status_success(bool v) { require_status_success_ = v; }
+
+  /// Require pull request to be mergeable.
+  bool require_mergeable_state() const { return require_mergeable_state_; }
+
+  /// Set require mergeable state flag.
+  void set_require_mergeable_state(bool v) { require_mergeable_state_ = v; }
+
   /// Prefix of branches to purge after merge.
   const std::string &purge_prefix() const { return purge_prefix_; }
 
@@ -266,6 +284,9 @@ private:
   bool purge_only_ = false;
   bool reject_dirty_ = false;
   bool auto_merge_ = false;
+  int required_approvals_ = 0;
+  bool require_status_success_ = false;
+  bool require_mergeable_state_ = false;
   std::string purge_prefix_;
   int pr_limit_ = 50;
   std::chrono::seconds pr_since_{0};

--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -176,6 +176,15 @@ public:
   /// Set minimum delay between HTTP requests in milliseconds.
   void set_delay_ms(int delay_ms);
 
+  /// Set required approvals before merging.
+  void set_required_approvals(int n) { required_approvals_ = n; }
+
+  /// Set whether successful status checks are required before merging.
+  void set_require_status_success(bool v) { require_status_success_ = v; }
+
+  /// Set whether a PR must be mergeable before merging.
+  void set_require_mergeable_state(bool v) { require_mergeable_state_ = v; }
+
   /**
    * List repositories accessible to the authenticated user.
    *
@@ -236,6 +245,10 @@ private:
   std::unique_ptr<HttpClient> http_;
   std::unordered_set<std::string> include_repos_;
   std::unordered_set<std::string> exclude_repos_;
+
+  int required_approvals_{0};
+  bool require_status_success_{false};
+  bool require_mergeable_state_{false};
 
   int delay_ms_;
   std::chrono::steady_clock::time_point last_request_;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -280,6 +280,16 @@ CliOptions parse_cli(int argc, char **argv) {
   app.add_flag("--auto-merge", options.auto_merge,
                "Automatically merge pull requests")
       ->group("Actions");
+  app.add_option("--require-approval", options.required_approvals,
+                 "Minimum number of approvals required before merging")
+      ->type_name("N")
+      ->group("Actions");
+  app.add_flag("--require-status-success", options.require_status_success,
+               "Require all status checks to succeed before merging")
+      ->group("Actions");
+  app.add_flag("--require-mergeable", options.require_mergeable_state,
+               "Require pull request to be mergeable")
+      ->group("Actions");
   app.add_option("--purge-prefix", options.purge_prefix,
                  "Delete branches with this prefix after PR close")
       ->type_name("PREFIX")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -149,6 +149,15 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("auto_merge")) {
     set_auto_merge(j["auto_merge"].get<bool>());
   }
+  if (j.contains("required_approvals")) {
+    set_required_approvals(j["required_approvals"].get<int>());
+  }
+  if (j.contains("require_status_success")) {
+    set_require_status_success(j["require_status_success"].get<bool>());
+  }
+  if (j.contains("require_mergeable_state")) {
+    set_require_mergeable_state(j["require_mergeable_state"].get<bool>());
+  }
   if (j.contains("purge_prefix")) {
     set_purge_prefix(j["purge_prefix"].get<std::string>());
   }

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -56,7 +56,11 @@ void GitHubPoller::poll() {
       all_prs.insert(all_prs.end(), prs.begin(), prs.end());
       if (auto_merge_) {
         for (const auto &pr : prs) {
-          client_.merge_pull_request(pr.owner, pr.repo, pr.number);
+          if (client_.merge_pull_request(pr.owner, pr.repo, pr.number)) {
+            if (log_cb_) {
+              log_cb_("Merged PR #" + std::to_string(pr.number));
+            }
+          }
         }
       }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,6 +50,17 @@ int main(int argc, char **argv) {
     agpm::GitHubClient client(token, nullptr, include_set, exclude_set,
                               delay_ms, http_timeout * 1000, http_retries);
 
+    int required_approvals = opts.required_approvals != 0
+                                 ? opts.required_approvals
+                                 : cfg.required_approvals();
+    bool require_status_success =
+        opts.require_status_success || cfg.require_status_success();
+    bool require_mergeable_state =
+        opts.require_mergeable_state || cfg.require_mergeable_state();
+    client.set_required_approvals(required_approvals);
+    client.set_require_status_success(require_status_success);
+    client.set_require_mergeable_state(require_mergeable_state);
+
     int interval =
         opts.poll_interval != 0 ? opts.poll_interval : cfg.poll_interval();
     int interval_ms = interval * 1000;

--- a/tests/test_auto_merge.cpp
+++ b/tests/test_auto_merge.cpp
@@ -14,6 +14,9 @@ public:
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
     (void)headers;
+    if (url.find("/pulls/") != std::string::npos) {
+      return "{}";
+    }
     if (url.find("/pulls") != std::string::npos) {
       return "[{\"number\":1,\"title\":\"PR\"}]";
     }

--- a/tests/test_github_client_accept.cpp
+++ b/tests/test_github_client_accept.cpp
@@ -10,8 +10,10 @@ public:
   std::vector<std::string> last_headers;
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
-    (void)url;
     last_headers = headers;
+    if (url.find("/pulls/") != std::string::npos) {
+      return "{}";
+    }
     return "[]";
   }
   std::string put(const std::string &url, const std::string &data,

--- a/tests/test_github_client_delay.cpp
+++ b/tests/test_github_client_delay.cpp
@@ -10,8 +10,10 @@ class DelayHttpClient : public HttpClient {
 public:
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
-    (void)url;
     (void)headers;
+    if (url.find("/pulls/") != std::string::npos) {
+      return "{}";
+    }
     return "[]";
   }
   std::string put(const std::string &url, const std::string &data,

--- a/tests/test_history_merge.cpp
+++ b/tests/test_history_merge.cpp
@@ -7,13 +7,16 @@ using namespace agpm;
 
 class DummyHttp : public HttpClient {
 public:
-  std::string resp_get;
+  std::string resp_list;
+  std::string resp_pr;
   std::string resp_put;
   std::string get(const std::string &url,
                   const std::vector<std::string> &headers) override {
-    (void)url;
     (void)headers;
-    return resp_get;
+    if (url.find("/pulls/") != std::string::npos) {
+      return resp_pr;
+    }
+    return resp_list;
   }
   std::string put(const std::string &url, const std::string &data,
                   const std::vector<std::string> &headers) override {
@@ -32,8 +35,9 @@ public:
 
 TEST_CASE("test history merge") {
   auto http = std::make_unique<DummyHttp>();
-  http->resp_get =
+  http->resp_list =
       "[{\"number\":1,\"title\":\"One\"},{\"number\":2,\"title\":\"Two\"}]";
+  http->resp_pr = "{}";
   http->resp_put = "{\"merged\":true}";
   DummyHttp *raw = http.get();
   (void)raw;

--- a/tests/test_merge_rules.cpp
+++ b/tests/test_merge_rules.cpp
@@ -1,0 +1,95 @@
+#include "github_client.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace agpm;
+
+class RuleHttpClient : public HttpClient {
+public:
+  std::string meta_response;
+  std::string merge_response{"{\"merged\":true}"};
+  int put_calls{0};
+  std::string last_put_url;
+
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)headers;
+    if (url.find("/pulls/") != std::string::npos) {
+      return meta_response;
+    }
+    return "";
+  }
+
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)data;
+    (void)headers;
+    last_put_url = url;
+    ++put_calls;
+    return merge_response;
+  }
+
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "";
+  }
+};
+
+TEST_CASE("merge rules allow merge") {
+  auto http = std::make_unique<RuleHttpClient>();
+  http->meta_response =
+      "{\"approvals\":2,\"mergeable\":true,\"mergeable_state\":\"clean\"}";
+  RuleHttpClient *raw = http.get();
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  client.set_required_approvals(1);
+  client.set_require_status_success(true);
+  client.set_require_mergeable_state(true);
+  bool merged = client.merge_pull_request("o", "r", 1);
+  REQUIRE(merged);
+  REQUIRE(raw->put_calls == 1);
+  REQUIRE(raw->last_put_url.find("/repos/o/r/pulls/1/merge") !=
+          std::string::npos);
+}
+
+TEST_CASE("merge rules block approvals") {
+  auto http = std::make_unique<RuleHttpClient>();
+  http->meta_response =
+      "{\"approvals\":0,\"mergeable\":true,\"mergeable_state\":\"clean\"}";
+  RuleHttpClient *raw = http.get();
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  client.set_required_approvals(1);
+  client.set_require_status_success(true);
+  client.set_require_mergeable_state(true);
+  bool merged = client.merge_pull_request("o", "r", 1);
+  REQUIRE_FALSE(merged);
+  REQUIRE(raw->put_calls == 0);
+}
+
+TEST_CASE("merge rules block status") {
+  auto http = std::make_unique<RuleHttpClient>();
+  http->meta_response =
+      "{\"approvals\":2,\"mergeable\":true,\"mergeable_state\":\"dirty\"}";
+  RuleHttpClient *raw = http.get();
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  client.set_required_approvals(1);
+  client.set_require_status_success(true);
+  client.set_require_mergeable_state(true);
+  bool merged = client.merge_pull_request("o", "r", 1);
+  REQUIRE_FALSE(merged);
+  REQUIRE(raw->put_calls == 0);
+}
+
+TEST_CASE("merge rules block mergeable") {
+  auto http = std::make_unique<RuleHttpClient>();
+  http->meta_response =
+      "{\"approvals\":2,\"mergeable\":false,\"mergeable_state\":\"clean\"}";
+  RuleHttpClient *raw = http.get();
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  client.set_required_approvals(1);
+  client.set_require_status_success(true);
+  client.set_require_mergeable_state(true);
+  bool merged = client.merge_pull_request("o", "r", 1);
+  REQUIRE_FALSE(merged);
+  REQUIRE(raw->put_calls == 0);
+}

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -28,6 +28,9 @@ public:
     last_method = "GET";
     last_url = url;
     ++get_count;
+    if (url.find("/pulls/") != std::string::npos) {
+      return "{}";
+    }
     return get_response;
   }
   std::string put(const std::string &url, const std::string &data,

--- a/tests/test_tui_merge.cpp
+++ b/tests/test_tui_merge.cpp
@@ -27,6 +27,9 @@ public:
     (void)headers;
     last_url = url;
     ++get_count;
+    if (url.find("/pulls/") != std::string::npos) {
+      return "{}";
+    }
     return get_response;
   }
   std::string put(const std::string &url, const std::string &data,


### PR DESCRIPTION
## Summary
- add configuration and CLI flags for merge rules
- check pull request metadata against rules before merging
- ensure auto-merges occur only when rules pass and add tests for merge rule compliance

## Testing
- `bash scripts/build_linux.sh` *(fails: OpenSSL build requires system kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a42d3c1883258b07c0a6e47a7f5d