### PR TITLE
fix: zero-initialize buffer in TUI test

### DIFF
--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -1,5 +1,6 @@
 #include "github_poller.hpp"
 #include "tui.hpp"
+#include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
 #include <cstdlib>
@@ -73,9 +74,9 @@ TEST_CASE("test tui") {
 
   ui.update_prs({{1, "Test PR", "o", "r"}});
   ui.draw();
-  char buf[80];
-  mvwinnstr(stdscr, 1, 1, buf, 79);
-  std::string line(buf);
+  std::array<char, 80> buf{};
+  mvwinnstr(stdscr, 1, 1, buf.data(), 79);
+  std::string line(buf.data());
   REQUIRE(line.find("Test PR") != std::string::npos);
   REQUIRE(line.find("o/r") != std::string::npos);
 


### PR DESCRIPTION
## Summary
- prevent uninitialized memory usage in TUI test buffer on macOS

## Testing
- `cmake --preset vcpkg` *(fails: Vcpkg toolchain file not found)*
- `clang-tidy tests/test_tui.cpp -- -std=c++20` *(fails: compiler error)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ee0f15ec83259e1e10c39a0c081c