### PR TITLE
fix: guard TUI init when stdin lacks TTY

### DIFF
--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -32,7 +32,10 @@ Tui::Tui(GitHubClient &client, GitHubPoller &poller)
 }
 
 void Tui::init() {
-  if (!isatty(fileno(stdout))) {
+  // Ensure both input and output are attached to a real terminal. macOS
+  // builds in CI environments may have one of these redirected which can
+  // cause ncurses to crash with a bus error when initializing.
+  if (!isatty(fileno(stdout)) || !isatty(fileno(stdin))) {
     return;
   }
   if (initscr() == nullptr) {


### PR DESCRIPTION
## Summary
- avoid initializing ncurses when either stdin or stdout is not a real terminal

## Testing
- `bash scripts/compile_linux.sh` *(fails: Fetching registry information from https://github.com/microsoft/vcpkg)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ee0f15ec83259e1e10c39a0c081c