### PR TITLE
feat: add merge rule checks and tests

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -209,6 +209,7 @@ public:
   /// Set auto merge flag.
   void set_auto_merge(bool v) { auto_merge_ = v; }
 
+  /// Merge rule configuration
   /// Required number of approvals before merging.
   int required_approvals() const { return required_approvals_; }
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -283,6 +283,7 @@ CliOptions parse_cli(int argc, char **argv) {
   app.add_option("--require-approval", options.required_approvals,
                  "Minimum number of approvals required before merging")
       ->type_name("N")
+      ->default_val("0")
       ->group("Actions");
   app.add_flag("--require-status-success", options.require_status_success,
                "Require all status checks to succeed before merging")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -149,6 +149,7 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("auto_merge")) {
     set_auto_merge(j["auto_merge"].get<bool>());
   }
+  // Merge rule settings
   if (j.contains("required_approvals")) {
     set_required_approvals(j["required_approvals"].get<int>());
   }

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -597,14 +597,18 @@ bool GitHubClient::merge_pull_request(const std::string &owner,
   if (!meta.is_object()) {
     return false;
   }
-  if (required_approvals_ > 0 &&
-      meta.value("approvals", 0) < required_approvals_) {
+  int approvals = meta.value("approvals", 0);
+  if (required_approvals_ > 0 && approvals < required_approvals_) {
+    spdlog::info("PR #{} requires {} approvals but has {}", pr_number,
+                 required_approvals_, approvals);
     return false;
   }
   if (require_status_success_ && meta.value("mergeable_state", "") != "clean") {
+    spdlog::info("PR #{} status checks not successful", pr_number);
     return false;
   }
   if (require_mergeable_state_ && !meta.value("mergeable", false)) {
+    spdlog::info("PR #{} is not mergeable", pr_number);
     return false;
   }
   enforce_delay();

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -56,10 +56,15 @@ void GitHubPoller::poll() {
       all_prs.insert(all_prs.end(), prs.begin(), prs.end());
       if (auto_merge_) {
         for (const auto &pr : prs) {
-          if (client_.merge_pull_request(pr.owner, pr.repo, pr.number)) {
+          bool merged =
+              client_.merge_pull_request(pr.owner, pr.repo, pr.number);
+          if (merged) {
             if (log_cb_) {
               log_cb_("Merged PR #" + std::to_string(pr.number));
             }
+          } else if (log_cb_) {
+            log_cb_("PR #" + std::to_string(pr.number) +
+                    " did not meet merge requirements");
           }
         }
       }

--- a/tests/test_merge_rules.cpp
+++ b/tests/test_merge_rules.cpp
@@ -93,3 +93,13 @@ TEST_CASE("merge rules block mergeable") {
   REQUIRE_FALSE(merged);
   REQUIRE(raw->put_calls == 0);
 }
+TEST_CASE("merge rules ignored when disabled") {
+  auto http = std::make_unique<RuleHttpClient>();
+  http->meta_response =
+      "{\"approvals\":0,\"mergeable\":false,\"mergeable_state\":\"dirty\"}";
+  RuleHttpClient *raw = http.get();
+  GitHubClient client("tok", std::unique_ptr<HttpClient>(http.release()));
+  bool merged = client.merge_pull_request("o", "r", 1);
+  REQUIRE(merged);
+  REQUIRE(raw->put_calls == 1);
+}


### PR DESCRIPTION
## Summary
- group merge-rule settings in config and parsing
- default CLI approval requirement and add detailed logs
- improve poller merge feedback and add tests for disabled rules

## Testing
- `scripts/build_linux.sh` *(fails: openssl requires Linux kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f0fff2a4832581ed9aa4bc4ac2d3