### PR TITLE
docs: add Doxygen comments to public interfaces

### DIFF
--- a/include/config_manager.hpp
+++ b/include/config_manager.hpp
@@ -9,7 +9,12 @@ namespace agpm {
 /// Utility class for loading configuration files.
 class ConfigManager {
 public:
-  /// Load a configuration from a YAML or JSON file.
+  /**
+   * Load a configuration from a YAML or JSON file.
+   *
+   * @param path Path to the configuration file on disk.
+   * @return Parsed configuration object.
+   */
   Config load(const std::string &path) const;
 };
 

--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -197,6 +197,9 @@ public:
    *
    * @param owner Repository owner
    * @param repo Repository name
+   * @param include_merged Include merged pull requests when true
+   * @param per_page Number of pull requests to fetch per page
+   * @param since Only include pull requests updated since this time
    * @return List of pull request summaries
    */
   std::vector<PullRequest>
@@ -217,6 +220,10 @@ public:
 
   /**
    * List branch names for a repository excluding the default branch.
+   *
+   * @param owner Repository owner
+   * @param repo Repository name
+   * @return All non-default branch names
    */
   std::vector<std::string> list_branches(const std::string &owner,
                                          const std::string &repo);
@@ -224,6 +231,13 @@ public:
   /**
    * Delete branches whose associated pull request was closed or merged and
    * whose name begins with the given prefix.
+   *
+   * @param owner Repository owner
+   * @param repo Repository name
+   * @param prefix Branch name prefix to match for deletion
+   * @param protected_branches Glob patterns for branches that must not be
+   *        deleted
+   * @param protected_branch_excludes Patterns that override protections
    */
   void cleanup_branches(
       const std::string &owner, const std::string &repo,
@@ -234,6 +248,12 @@ public:
   /**
    * Close or delete branches that have diverged from the repository's default
    * branch.
+   *
+   * @param owner Repository owner
+   * @param repo Repository name
+   * @param protected_branches Glob patterns for branches that must not be
+   *        removed
+   * @param protected_branch_excludes Patterns that override protections
    */
   void close_dirty_branches(
       const std::string &owner, const std::string &repo,

--- a/include/github_poller.hpp
+++ b/include/github_poller.hpp
@@ -21,6 +21,17 @@ public:
    * @param repos List of {owner, repo} pairs to poll
    * @param interval_ms Poll interval in milliseconds
    * @param max_rate Maximum requests per minute
+   * @param only_poll_prs When true, skip branch polling
+   * @param only_poll_stray When true, only poll branches for stray detection
+   * @param reject_dirty Automatically close or delete dirty branches
+   * @param purge_prefix Delete merged branches starting with this prefix
+   * @param auto_merge Automatically merge qualifying pull requests
+   * @param purge_only Only purge branches without polling PRs
+   * @param sort_mode Sort mode for pull request listing
+   * @param history Optional PR history database for export
+   * @param protected_branches Glob patterns for branches that must not be
+   *        removed
+   * @param protected_branch_excludes Patterns that override protections
    */
   GitHubPoller(GitHubClient &client,
                std::vector<std::pair<std::string, std::string>> repos,
@@ -40,14 +51,26 @@ public:
   /// Invoke the polling routine immediately on the current thread.
   void poll_now();
 
-  /// Set a callback invoked with the current pull requests after each poll.
+  /**
+   * Set a callback invoked with the current pull requests after each poll.
+   *
+   * @param cb Function receiving the latest pull request list
+   */
   void
   set_pr_callback(std::function<void(const std::vector<PullRequest> &)> cb);
 
-  /// Set a callback invoked for log messages produced during polling.
+  /**
+   * Set a callback invoked for log messages produced during polling.
+   *
+   * @param cb Function receiving log messages
+   */
   void set_log_callback(std::function<void(const std::string &)> cb);
 
-  /// Set a callback invoked after each poll to export stored history.
+  /**
+   * Set a callback invoked after each poll to export stored history.
+   *
+   * @param cb Function to run after each poll cycle
+   */
   void set_export_callback(std::function<void()> cb);
 
 private:

--- a/include/sort.hpp
+++ b/include/sort.hpp
@@ -9,6 +9,14 @@
 
 namespace agpm {
 
+/**
+ * Compare two strings using natural order where digit sequences are
+ * interpreted as numbers.
+ *
+ * @param a First string
+ * @param b Second string
+ * @return True if `a` should appear before `b`
+ */
 inline bool alphanum_less(const std::string &a, const std::string &b) {
   size_t i = 0, j = 0;
   while (i < a.size() && j < b.size()) {
@@ -40,6 +48,13 @@ inline bool alphanum_less(const std::string &a, const std::string &b) {
   return a.size() < b.size();
 }
 
+/**
+ * Sort a list of pull requests by title using the provided mode.
+ *
+ * @param prs Pull requests to sort in-place
+ * @param mode Sorting mode: "alpha", "reverse", "alphanum",
+ *             or "reverse-alphanum"
+ */
 inline void sort_pull_requests(std::vector<PullRequest> &prs,
                                const std::string &mode) {
   if (mode == "alpha") {

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -23,7 +23,12 @@ namespace agpm {
  */
 class Tui {
 public:
-  /// Construct a TUI bound to a GitHub client and poller.
+  /**
+   * Construct a TUI bound to a GitHub client and poller.
+   *
+   * @param client GitHub API client used for interactive actions
+   * @param poller Poller providing periodic updates
+   */
   Tui(GitHubClient &client, GitHubPoller &poller);
 
   /// Initialize the curses library and windows.
@@ -35,13 +40,21 @@ public:
   /// Clean up curses state.
   void cleanup();
 
-  /// Update the displayed pull requests.
+  /**
+   * Update the displayed pull requests.
+   *
+   * @param prs Latest list of pull requests to render
+   */
   void update_prs(const std::vector<PullRequest> &prs);
 
   /// Draw the interface once.
   void draw();
 
-  /// Handle a single key press.
+  /**
+   * Handle a single key press.
+   *
+   * @param ch Character code received from curses
+   */
   void handle_key(int ch);
 
   /// Access collected log messages.

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -52,6 +52,7 @@ void GitHubPoller::poll() {
   std::vector<PullRequest> all_prs;
   for (const auto &r : repos_) {
     if (purge_only_) {
+      // In purge-only mode skip all polling and just delete branches.
       spdlog::debug("purge_only set - skipping repo {}/{}", r.first, r.second);
       if (!purge_prefix_.empty()) {
         client_.cleanup_branches(r.first, r.second, purge_prefix_,
@@ -61,6 +62,7 @@ void GitHubPoller::poll() {
       continue;
     }
     if (!only_poll_stray_) {
+      // Fetch pull requests and optionally merge them when allowed.
       auto prs = client_.list_pull_requests(r.first, r.second);
       all_prs.insert(all_prs.end(), prs.begin(), prs.end());
       if (auto_merge_) {
@@ -79,6 +81,7 @@ void GitHubPoller::poll() {
       }
     }
     if (!only_poll_prs_) {
+      // Gather stray branches not matching the purge prefix for logging.
       auto branches = client_.list_branches(r.first, r.second);
       std::vector<std::string> stray;
       for (const auto &b : branches) {


### PR DESCRIPTION
## Summary
- document configuration loading and parsing
- expand GitHub client and poller API documentation
- clarify sort, TUI, and internal branch management logic

## Testing
- `doxygen docs/Doxyfile` *(fails: dot: not found)*
- `cmake -B build` *(fails: Vcpkg toolchain file not found)*
- `bash scripts/install_linux.sh` *(fails: openssl requires linux-libc-dev)*

------
https://chatgpt.com/codex/tasks/task_e_68aa270680088325ba8662c2570caae1