### PR TITLE
feat: add worker thread pool

### DIFF
--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -32,6 +32,7 @@ struct CliOptions {
   std::string export_json;               ///< Path to export JSON file
   int poll_interval = 0;                 ///< Polling interval in seconds
   int max_request_rate = 60;             ///< Max requests per minute
+  int workers = 0;                       ///< Number of worker threads
   int http_timeout = 30;                 ///< HTTP timeout in seconds
   int http_retries = 3;                  ///< Number of HTTP retries
   long long download_limit = 0;          ///< Download rate limit (bytes/sec)

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -29,6 +29,12 @@ public:
   /// Set maximum request rate.
   void set_max_request_rate(int rate) { max_request_rate_ = rate; }
 
+  /// Number of worker threads.
+  int workers() const { return workers_; }
+
+  /// Set worker thread count.
+  void set_workers(int w) { workers_ = w; }
+
   /// HTTP request timeout in seconds.
   int http_timeout() const { return http_timeout_; }
 
@@ -265,6 +271,7 @@ private:
   bool verbose_ = false;
   int poll_interval_ = 0;
   int max_request_rate_ = 60;
+  int workers_ = 4;
   std::string log_level_ = "info";
   std::string log_pattern_;
   std::string log_file_;

--- a/include/github_poller.hpp
+++ b/include/github_poller.hpp
@@ -4,8 +4,10 @@
 #include "github_client.hpp"
 #include "history.hpp"
 #include "poller.hpp"
+#include <atomic>
 #include <functional>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -35,8 +37,9 @@ public:
    */
   GitHubPoller(GitHubClient &client,
                std::vector<std::pair<std::string, std::string>> repos,
-               int interval_ms, int max_rate, bool only_poll_prs = false,
-               bool only_poll_stray = false, bool reject_dirty = false,
+               int interval_ms, int max_rate, int workers = 1,
+               bool only_poll_prs = false, bool only_poll_stray = false,
+               bool reject_dirty = false,
                std::string purge_prefix = "", bool auto_merge = false,
                bool purge_only = false, std::string sort_mode = "",
                PullRequestHistory *history = nullptr,
@@ -79,6 +82,9 @@ private:
   GitHubClient &client_;
   std::vector<std::pair<std::string, std::string>> repos_;
   Poller poller_;
+  int interval_ms_;
+  std::thread thread_;
+  std::atomic<bool> running_{false};
   bool only_poll_prs_;
   bool only_poll_stray_;
   bool reject_dirty_;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -225,6 +225,11 @@ CliOptions parse_cli(int argc, char **argv) {
       ->type_name("RATE")
       ->default_val("60")
       ->group("Polling");
+  app.add_option("--workers", options.workers,
+                 "Number of worker threads")
+      ->type_name("N")
+      ->default_val("0")
+      ->group("Polling");
   app.add_option("--http-timeout", options.http_timeout,
                  "HTTP request timeout in seconds")
       ->type_name("SECONDS")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -70,6 +70,9 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("max_request_rate")) {
     set_max_request_rate(j["max_request_rate"].get<int>());
   }
+  if (j.contains("workers")) {
+    set_workers(j["workers"].get<int>());
+  }
   if (j.contains("http_timeout")) {
     set_http_timeout(j["http_timeout"].get<int>());
   }

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -1,5 +1,7 @@
 #include "github_poller.hpp"
 #include "sort.hpp"
+#include <future>
+#include <mutex>
 #include <spdlog/spdlog.h>
 
 namespace agpm {
@@ -7,27 +9,39 @@ namespace agpm {
 GitHubPoller::GitHubPoller(
     GitHubClient &client,
     std::vector<std::pair<std::string, std::string>> repos, int interval_ms,
-    int max_rate, bool only_poll_prs, bool only_poll_stray, bool reject_dirty,
-    std::string purge_prefix, bool auto_merge, bool purge_only,
-    std::string sort_mode, PullRequestHistory *history,
+    int max_rate, int workers, bool only_poll_prs, bool only_poll_stray,
+    bool reject_dirty, std::string purge_prefix, bool auto_merge,
+    bool purge_only, std::string sort_mode, PullRequestHistory *history,
     std::vector<std::string> protected_branches,
     std::vector<std::string> protected_branch_excludes)
-    : client_(client), repos_(std::move(repos)),
-      poller_([this] { poll(); }, interval_ms, max_rate),
-      only_poll_prs_(only_poll_prs), only_poll_stray_(only_poll_stray),
-      reject_dirty_(reject_dirty), purge_prefix_(std::move(purge_prefix)),
-      auto_merge_(auto_merge), purge_only_(purge_only),
-      sort_mode_(std::move(sort_mode)), history_(history),
-      protected_branches_(std::move(protected_branches)),
-      protected_branch_excludes_(std::move(protected_branch_excludes)) {}
+    : client_(client), repos_(std::move(repos)), poller_(workers, max_rate),
+      interval_ms_(interval_ms), only_poll_prs_(only_poll_prs),
+      only_poll_stray_(only_poll_stray), reject_dirty_(reject_dirty),
+      purge_prefix_(std::move(purge_prefix)), auto_merge_(auto_merge),
+      purge_only_(purge_only), sort_mode_(std::move(sort_mode)),
+      history_(history), protected_branches_(std::move(protected_branches)),
+      protected_branch_excludes_(
+          std::move(protected_branch_excludes)) {}
 
 void GitHubPoller::start() {
   spdlog::info("Starting GitHub poller");
   poller_.start();
+  running_ = true;
+  thread_ = std::thread([this] {
+    while (running_) {
+      poll();
+      std::this_thread::sleep_for(
+          std::chrono::milliseconds(interval_ms_));
+    }
+  });
 }
 
 void GitHubPoller::stop() {
   spdlog::info("Stopping GitHub poller");
+  running_ = false;
+  if (thread_.joinable()) {
+    thread_.join();
+  }
   poller_.stop();
 }
 
@@ -50,66 +64,83 @@ void GitHubPoller::set_export_callback(std::function<void()> cb) {
 void GitHubPoller::poll() {
   spdlog::debug("Polling repositories");
   std::vector<PullRequest> all_prs;
-  for (const auto &r : repos_) {
-    if (purge_only_) {
-      // In purge-only mode skip all polling and just delete branches.
-      spdlog::debug("purge_only set - skipping repo {}/{}", r.first, r.second);
-      if (!purge_prefix_.empty()) {
-        client_.cleanup_branches(r.first, r.second, purge_prefix_,
-                                 protected_branches_,
-                                 protected_branch_excludes_);
-      }
-      continue;
-    }
-    if (!only_poll_stray_) {
-      // Fetch pull requests and optionally merge them when allowed.
-      auto prs = client_.list_pull_requests(r.first, r.second);
-      all_prs.insert(all_prs.end(), prs.begin(), prs.end());
-      if (history_) {
-        for (const auto &pr : prs) {
-          history_->insert(pr.number, pr.title, pr.merged);
+  std::mutex pr_mutex;
+  std::mutex log_mutex;
+  std::vector<std::future<void>> futures;
+  for (const auto &repo : repos_) {
+    futures.push_back(poller_.submit([this, repo, &all_prs, &pr_mutex,
+                                      &log_mutex] {
+      if (purge_only_) {
+        spdlog::debug("purge_only set - skipping repo {}/{}", repo.first,
+                      repo.second);
+        if (!purge_prefix_.empty()) {
+          client_.cleanup_branches(repo.first, repo.second, purge_prefix_,
+                                   protected_branches_,
+                                   protected_branch_excludes_);
         }
+        return;
       }
-      if (auto_merge_) {
-        for (const auto &pr : prs) {
-          bool merged =
-              client_.merge_pull_request(pr.owner, pr.repo, pr.number);
-          if (merged) {
-            if (history_) {
-              history_->update_merged(pr.number);
+      std::vector<PullRequest> prs;
+      if (!only_poll_stray_) {
+        prs = client_.list_pull_requests(repo.first, repo.second);
+        {
+          std::lock_guard<std::mutex> lk(pr_mutex);
+          all_prs.insert(all_prs.end(), prs.begin(), prs.end());
+          if (history_) {
+            for (const auto &pr : prs) {
+              history_->insert(pr.number, pr.title, pr.merged);
             }
-            if (log_cb_) {
-              log_cb_("Merged PR #" + std::to_string(pr.number));
+          }
+        }
+        if (auto_merge_) {
+          for (const auto &pr : prs) {
+            bool merged =
+                client_.merge_pull_request(pr.owner, pr.repo, pr.number);
+            if (merged) {
+              if (history_) {
+                std::lock_guard<std::mutex> lk(pr_mutex);
+                history_->update_merged(pr.number);
+              }
+              if (log_cb_) {
+                std::lock_guard<std::mutex> lk(log_mutex);
+                log_cb_("Merged PR #" + std::to_string(pr.number));
+              }
+            } else if (log_cb_) {
+              std::lock_guard<std::mutex> lk(log_mutex);
+              log_cb_("PR #" + std::to_string(pr.number) +
+                      " did not meet merge requirements");
             }
-          } else if (log_cb_) {
-            log_cb_("PR #" + std::to_string(pr.number) +
-                    " did not meet merge requirements");
           }
         }
       }
-    }
-    if (!only_poll_prs_) {
-      // Gather stray branches not matching the purge prefix for logging.
-      auto branches = client_.list_branches(r.first, r.second);
-      std::vector<std::string> stray;
-      for (const auto &b : branches) {
-        if (purge_prefix_.empty() || b.rfind(purge_prefix_, 0) != 0) {
-          stray.push_back(b);
+      if (!only_poll_prs_) {
+        auto branches = client_.list_branches(repo.first, repo.second);
+        std::vector<std::string> stray;
+        for (const auto &b : branches) {
+          if (purge_prefix_.empty() || b.rfind(purge_prefix_, 0) != 0) {
+            stray.push_back(b);
+          }
+        }
+        if (log_cb_) {
+          std::lock_guard<std::mutex> lk(log_mutex);
+          log_cb_(repo.first + "/" + repo.second +
+                  " stray branches: " + std::to_string(stray.size()));
         }
       }
-      if (log_cb_) {
-        log_cb_(r.first + "/" + r.second +
-                " stray branches: " + std::to_string(stray.size()));
+      if (!purge_prefix_.empty()) {
+        client_.cleanup_branches(repo.first, repo.second, purge_prefix_,
+                                 protected_branches_,
+                                 protected_branch_excludes_);
       }
-    }
-    if (!purge_prefix_.empty()) {
-      client_.cleanup_branches(r.first, r.second, purge_prefix_,
-                               protected_branches_, protected_branch_excludes_);
-    }
-    if (!only_poll_prs_ && reject_dirty_) {
-      client_.close_dirty_branches(r.first, r.second, protected_branches_,
-                                   protected_branch_excludes_);
-    }
+      if (!only_poll_prs_ && reject_dirty_) {
+        client_.close_dirty_branches(repo.first, repo.second,
+                                     protected_branches_,
+                                     protected_branch_excludes_);
+      }
+    }));
+  }
+  for (auto &f : futures) {
+    f.get();
   }
   sort_pull_requests(all_prs, sort_mode_);
   if (pr_cb_) {
@@ -120,6 +151,7 @@ void GitHubPoller::poll() {
     export_cb_();
   }
   if (log_cb_) {
+    std::lock_guard<std::mutex> lk(log_mutex);
     log_cb_("Polled " + std::to_string(all_prs.size()) + " pull requests");
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,9 @@ int main(int argc, char **argv) {
     bool auto_merge = opts.auto_merge || cfg.auto_merge();
     bool purge_only = opts.purge_only || cfg.purge_only();
     std::string sort_mode = !opts.sort.empty() ? opts.sort : cfg.sort_mode();
+    int workers = opts.workers != 0 ? opts.workers : cfg.workers();
+    if (workers <= 0)
+      workers = 1;
 
     std::vector<std::pair<std::string, std::string>> repos;
     for (const auto &r : include) {
@@ -90,9 +93,9 @@ int main(int argc, char **argv) {
     agpm::PullRequestHistory history(history_db);
 
     agpm::GitHubPoller poller(
-        client, repos, interval_ms, max_rate, only_poll_prs, only_poll_stray,
-        reject_dirty, purge_prefix, auto_merge, purge_only, sort_mode, &history,
-        protected_branches, protected_branch_excludes);
+        client, repos, interval_ms, max_rate, workers, only_poll_prs,
+        only_poll_stray, reject_dirty, purge_prefix, auto_merge, purge_only,
+        sort_mode, &history, protected_branches, protected_branch_excludes);
 
     if (!opts.export_csv.empty() || !opts.export_json.empty()) {
       poller.set_export_callback([&history, &opts]() {

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -1,36 +1,63 @@
 #include "poller.hpp"
 #include <algorithm>
+#include <memory>
 #include <thread>
 
 namespace agpm {
 
-Poller::Poller(std::function<void()> task, int interval_ms, int max_rate)
-    : task_(std::move(task)), interval_ms_(interval_ms), max_rate_(max_rate),
-      tokens_(max_rate), capacity_(max_rate),
-      fill_rate_(static_cast<double>(max_rate) / 60.0) {}
+Poller::Poller(int workers, int max_rate)
+    : workers_(workers), max_rate_(max_rate), tokens_(max_rate),
+      capacity_(max_rate),
+      fill_rate_(max_rate > 0 ? static_cast<double>(max_rate) / 60.0 : 0.0) {}
 
 Poller::~Poller() { stop(); }
 
 void Poller::start() {
-  if (running_) {
+  if (running_)
     return;
-  }
   running_ = true;
   last_fill_ = std::chrono::steady_clock::now();
-  thread_ = std::thread(&Poller::run, this);
+  for (int i = 0; i < workers_; ++i) {
+    threads_.emplace_back(&Poller::worker, this);
+  }
 }
 
 void Poller::stop() {
-  if (!running_) {
+  if (!running_)
     return;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    running_ = false;
   }
-  running_ = false;
-  if (thread_.joinable()) {
-    thread_.join();
+  cv_.notify_all();
+  for (auto &t : threads_) {
+    if (t.joinable())
+      t.join();
   }
+  threads_.clear();
 }
 
-void Poller::run() {
+std::future<void> Poller::submit(std::function<void()> job) {
+  if (!running_) {
+    std::packaged_task<void()> pt(std::move(job));
+    auto fut = pt.get_future();
+    pt();
+    return fut;
+  }
+  auto task = std::make_shared<std::packaged_task<void()>>(std::move(job));
+  std::future<void> fut = task->get_future();
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    jobs_.emplace([task]() { (*task)(); });
+  }
+  cv_.notify_one();
+  return fut;
+}
+
+void Poller::acquire_token() {
+  if (max_rate_ <= 0)
+    return;
+  std::unique_lock<std::mutex> lock(rate_mutex_);
   while (running_) {
     auto now = std::chrono::steady_clock::now();
     double elapsed = std::chrono::duration<double>(now - last_fill_).count();
@@ -38,10 +65,29 @@ void Poller::run() {
     last_fill_ = now;
     if (tokens_ >= 1.0) {
       tokens_ -= 1.0;
-      task_();
+      return;
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms_));
+    lock.unlock();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    lock.lock();
+  }
+}
+
+void Poller::worker() {
+  while (true) {
+    std::function<void()> job;
+    {
+      std::unique_lock<std::mutex> lock(mutex_);
+      cv_.wait(lock, [this] { return !running_ || !jobs_.empty(); });
+      if (!running_ && jobs_.empty())
+        return;
+      job = std::move(jobs_.front());
+      jobs_.pop();
+    }
+    acquire_token();
+    job();
   }
 }
 
 } // namespace agpm
+


### PR DESCRIPTION
## Summary
- add configurable worker thread count via CLI and config
- replace poller with rate-limited thread pool
- parallelize GitHub polling with thread-safe logging

## Testing
- `make` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4c66f9f48325ab55ecc4b1ebdf45