### PR TITLE
feat: add workers option and concurrency tests for poller

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -29,11 +29,11 @@ public:
   /// Set maximum request rate.
   void set_max_request_rate(int rate) { max_request_rate_ = rate; }
 
-  /// Number of worker threads.
+  /// Number of worker threads used for polling operations.
   int workers() const { return workers_; }
 
-  /// Set worker thread count.
-  void set_workers(int w) { workers_ = w; }
+  /// Set worker thread count (minimum 1).
+  void set_workers(int w) { workers_ = w < 1 ? 1 : w; }
 
   /// HTTP request timeout in seconds.
   int http_timeout() const { return http_timeout_; }
@@ -271,7 +271,7 @@ private:
   bool verbose_ = false;
   int poll_interval_ = 0;
   int max_request_rate_ = 60;
-  int workers_ = 4;
+  int workers_ = 4; ///< Default number of worker threads
   std::string log_level_ = "info";
   std::string log_pattern_;
   std::string log_file_;

--- a/include/poller.hpp
+++ b/include/poller.hpp
@@ -14,8 +14,8 @@
 namespace agpm {
 
 /**
- * Thread pool executing submitted tasks while enforcing a maximum request
- * rate using a token bucket.
+ * Thread pool executing submitted polling tasks across multiple workers while
+ * enforcing a maximum request rate using a token bucket.
  */
 class Poller {
 public:
@@ -62,4 +62,3 @@ private:
 } // namespace agpm
 
 #endif // AUTOGITHUBPULLMERGE_POLLER_HPP
-

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -225,9 +225,9 @@ CliOptions parse_cli(int argc, char **argv) {
       ->type_name("RATE")
       ->default_val("60")
       ->group("Polling");
-  app.add_option("--workers", options.workers,
-                 "Number of worker threads")
+  app.add_option("--workers", options.workers, "Number of worker threads")
       ->type_name("N")
+      ->check(CLI::PositiveNumber)
       ->default_val("0")
       ->group("Polling");
   app.add_option("--http-timeout", options.http_timeout,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,5 +1,6 @@
 #include "config.hpp"
 #include "util/duration.hpp"
+#include <algorithm>
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -71,7 +72,7 @@ void Config::load_json(const nlohmann::json &j) {
     set_max_request_rate(j["max_request_rate"].get<int>());
   }
   if (j.contains("workers")) {
-    set_workers(j["workers"].get<int>());
+    set_workers(std::max(1, j["workers"].get<int>()));
   }
   if (j.contains("http_timeout")) {
     set_http_timeout(j["http_timeout"].get<int>());

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -6,7 +6,7 @@
 namespace agpm {
 
 Poller::Poller(int workers, int max_rate)
-    : workers_(workers), max_rate_(max_rate), tokens_(max_rate),
+    : workers_(std::max(1, workers)), max_rate_(max_rate), tokens_(max_rate),
       capacity_(max_rate),
       fill_rate_(max_rate > 0 ? static_cast<double>(max_rate) / 60.0 : 0.0) {}
 
@@ -17,6 +17,7 @@ void Poller::start() {
     return;
   running_ = true;
   last_fill_ = std::chrono::steady_clock::now();
+  threads_.reserve(workers_);
   for (int i = 0; i < workers_; ++i) {
     threads_.emplace_back(&Poller::worker, this);
   }
@@ -90,4 +91,3 @@ void Poller::worker() {
 }
 
 } // namespace agpm
-

--- a/tests/test_poller.cpp
+++ b/tests/test_poller.cpp
@@ -2,7 +2,9 @@
 #include <atomic>
 #include <catch2/catch_test_macros.hpp>
 #include <chrono>
+#include <future>
 #include <thread>
+#include <vector>
 
 using namespace agpm;
 
@@ -29,3 +31,25 @@ TEST_CASE("thread pool runs tasks concurrently") {
   REQUIRE(elapsed < 180);
 }
 
+TEST_CASE("thread pool handles more tasks than workers") {
+  Poller p(2, 0);
+  p.start();
+  std::atomic<int> count{0};
+  auto start = std::chrono::steady_clock::now();
+  std::vector<std::future<void>> futs;
+  for (int i = 0; i < 4; ++i) {
+    futs.push_back(p.submit([&] {
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+      ++count;
+    }));
+  }
+  for (auto &f : futs) {
+    f.get();
+  }
+  auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     std::chrono::steady_clock::now() - start)
+                     .count();
+  p.stop();
+  REQUIRE(count == 4);
+  REQUIRE(elapsed < 360);
+}


### PR DESCRIPTION
## Summary
- allow specifying number of worker threads with `--workers`
- clamp worker thread count in config and poller implementation
- cover poller thread pool with additional concurrency tests

## Testing
- `bash scripts/install_linux.sh` *(failed: OpenSSL requires system linux headers)*
- `bash scripts/build_linux.sh` *(failed: OpenSSL requires system linux headers)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e2c80c48325851c603337606cbb