### PR TITLE
fix: ensure windows scripts use msvc

### DIFF
--- a/scripts/build_win.bat
+++ b/scripts/build_win.bat
@@ -1,6 +1,12 @@
 @echo off
 setlocal
 
+rem Clear any preset compiler variables that may interfere with MSVC detection
+set "CC="
+set "CXX="
+set "CC_COMPILER="
+set "CXX_COMPILER="
+
 echo ============================================================
 echo   AutoGitHubPullMerge Windows Build and Test
 echo ============================================================
@@ -65,7 +71,8 @@ cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_TOOLCHAIN_FILE="%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake" ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
   -DCMAKE_CXX_STANDARD=23 ^
-  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+  -DCMAKE_C_COMPILER=cl ^
+  -DCMAKE_CXX_COMPILER=cl || exit /b 1
 
 echo [6/8] Building project...
 cmake --build build\vcpkg --config Release || exit /b 1

--- a/scripts/compile_win.bat
+++ b/scripts/compile_win.bat
@@ -1,6 +1,12 @@
 @echo off
 setlocal
 
+rem Clear any preset compiler variables that may interfere with MSVC detection
+set "CC="
+set "CXX="
+set "CC_COMPILER="
+set "CXX_COMPILER="
+
 echo ============================================================
 echo   AutoGitHubPullMerge Windows Compilation
 echo ============================================================
@@ -60,7 +66,8 @@ cmake -S . -B build\vcpkg -G "Ninja Multi-Config" ^
   -DCMAKE_CXX_STANDARD=23 ^
   -DCMAKE_TOOLCHAIN_FILE="%CD%\vcpkg\scripts\buildsystems\vcpkg.cmake" ^
   -DVCPKG_TARGET_TRIPLET=x64-windows-static ^
-  -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl || exit /b 1
+  -DCMAKE_C_COMPILER=cl ^
+  -DCMAKE_CXX_COMPILER=cl || exit /b 1
 
 echo [6/7] Building project...
 cmake --build build\vcpkg --config Release --target autogithubpullmerge || exit /b 1


### PR DESCRIPTION
## Summary
- clear stray compiler environment variables in Windows build scripts
- explicitly set cl as C and C++ compiler during Windows builds

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68ac98e1182483259053764c812d3071