### PR TITLE
Fix GitHubPoller tests for updated constructor

### DIFF
--- a/tests/test_auto_merge.cpp
+++ b/tests/test_auto_merge.cpp
@@ -42,7 +42,7 @@ TEST_CASE("test auto merge") {
   auto http = std::make_unique<MergeHttpClient>();
   MergeHttpClient *raw = http.get();
   GitHubClient client({"tok"}, std::unique_ptr<HttpClient>(http.release()));
-  GitHubPoller poller(client, {{"me", "repo"}}, 50, 120, false, false, false,
+  GitHubPoller poller(client, {{"me", "repo"}}, 50, 120, 1, false, false, false,
                       "", true);
   poller.start();
   std::this_thread::sleep_for(std::chrono::milliseconds(80));

--- a/tests/test_github_poller.cpp
+++ b/tests/test_github_poller.cpp
@@ -91,7 +91,7 @@ TEST_CASE("github poller sorts pull requests") {
   SECTION("alphanum") {
     auto http = std::make_unique<JsonHttpClient>(json);
     GitHubClient client({"tok"}, std::unique_ptr<HttpClient>(http.release()));
-    GitHubPoller poller(client, repos, 0, 60, true, false, false, "", false,
+    GitHubPoller poller(client, repos, 0, 60, 1, true, false, false, "", false,
                         false, "alphanum");
     std::vector<std::string> titles;
     poller.set_pr_callback([&](const std::vector<PullRequest> &prs) {
@@ -105,7 +105,7 @@ TEST_CASE("github poller sorts pull requests") {
   SECTION("reverse") {
     auto http = std::make_unique<JsonHttpClient>(json);
     GitHubClient client({"tok"}, std::unique_ptr<HttpClient>(http.release()));
-    GitHubPoller poller(client, repos, 0, 60, true, false, false, "", false,
+    GitHubPoller poller(client, repos, 0, 60, 1, true, false, false, "", false,
                         false, "reverse");
     std::vector<std::string> titles;
     poller.set_pr_callback([&](const std::vector<PullRequest> &prs) {

--- a/tests/test_history.cpp
+++ b/tests/test_history.cpp
@@ -43,8 +43,8 @@ TEST_CASE("test history") {
   char *argv[] = {prog, csv_flag, csv_path, json_flag, json_path};
   CliOptions opts = parse_cli(5, argv);
 
-  GitHubPoller poller(client, {{"me", "repo"}}, 0, 120, false, false, false, "",
-                      false, false, "", &hist);
+  GitHubPoller poller(client, {{"me", "repo"}}, 0, 120, 1, false, false, false,
+                      "", false, false, "", &hist);
 
   if (!opts.export_csv.empty() || !opts.export_json.empty()) {
     poller.set_export_callback([&]() {

--- a/tests/test_poller_branch.cpp
+++ b/tests/test_poller_branch.cpp
@@ -93,7 +93,7 @@ TEST_CASE("test poller branch") {
     auto http = std::make_unique<BranchListClient>();
     BranchListClient *raw = http.get();
     GitHubClient client({"tok"}, std::unique_ptr<HttpClient>(http.release()));
-    GitHubPoller poller(client, {{"me", "repo"}}, 1000, 60, false, true);
+    GitHubPoller poller(client, {{"me", "repo"}}, 1000, 60, 1, false, true);
     std::string msg;
     poller.set_log_callback([&](const std::string &m) { msg = m; });
     poller.poll_now();
@@ -107,8 +107,8 @@ TEST_CASE("test poller branch") {
     auto http = std::make_unique<BranchCleanupClient>();
     BranchCleanupClient *raw = http.get();
     GitHubClient client({"tok"}, std::unique_ptr<HttpClient>(http.release()));
-    GitHubPoller poller(client, {{"me", "repo"}}, 1000, 60, false, true, true,
-                        "tmp/");
+    GitHubPoller poller(client, {{"me", "repo"}}, 1000, 60, 1, false, true,
+                        true, "tmp/");
     poller.poll_now();
     REQUIRE(raw->deleted.count(raw->base + "/git/refs/heads/feature") == 1);
     REQUIRE(raw->deleted.count(raw->base + "/git/refs/heads/tmp/purge") == 1);


### PR DESCRIPTION
## Summary
- update GitHubPoller unit tests to pass explicit worker count

## Testing
- `make build` *(fails: agpm_tests segfault)*

------
https://chatgpt.com/codex/tasks/task_e_68aca62805588325a56351955d3c80f9