### PR TITLE
fix: include merged field in TUI tests

### DIFF
--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -72,7 +72,7 @@ TEST_CASE("test tui") {
   Tui ui(client, poller);
   ui.init();
 
-  ui.update_prs({{1, "Test PR", "o", "r"}});
+  ui.update_prs({{1, "Test PR", false, "o", "r"}});
   ui.draw();
   std::array<char, 80> buf{};
   mvwinnstr(stdscr, 1, 1, buf.data(), 79);

--- a/tests/test_tui_log_limit.cpp
+++ b/tests/test_tui_log_limit.cpp
@@ -66,7 +66,7 @@ TEST_CASE("test tui log limit") {
   Tui ui(client, poller);
 
   for (int i = 0; i < 205; ++i) {
-    ui.update_prs({{i, "PR", "o", "r"}});
+    ui.update_prs({{i, "PR", false, "o", "r"}});
     ui.handle_key('m');
   }
 

--- a/tests/test_tui_resize.cpp
+++ b/tests/test_tui_resize.cpp
@@ -57,7 +57,7 @@ TEST_CASE("test tui resize") {
   Tui ui(client, poller);
   ui.init();
 
-  ui.update_prs({{1, "PR", "o", "r"}});
+  ui.update_prs({{1, "PR", false, "o", "r"}});
   ui.draw();
   WINDOW *before = ui.pr_win_;
   int h, w;


### PR DESCRIPTION
## Summary
- fix narrowing conversion in TUI unit tests by inserting missing `merged` field in `PullRequest` initializers

## Testing
- `cmake -S . -B build` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acad17f400832581ec016eaf4d76d3