### PR TITLE
feat(tui): add browser and detail hotkeys

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -13,6 +13,7 @@
 
 #include "github_client.hpp"
 #include "github_poller.hpp"
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -71,6 +72,10 @@ private:
   WINDOW *pr_win_{nullptr};
   WINDOW *log_win_{nullptr};
   WINDOW *help_win_{nullptr};
+  WINDOW *detail_win_{nullptr};
+  bool detail_visible_{false};
+  std::string detail_text_;
+  std::function<int(const std::string &)> open_cmd_;
   bool running_{false};
   bool initialized_{false};
   int last_h_{0}; ///< Cached terminal height for resize detection.

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -1,5 +1,7 @@
 #include "github_poller.hpp"
+#define private public
 #include "tui.hpp"
+#undef private
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
@@ -79,6 +81,13 @@ TEST_CASE("test tui") {
   std::string line(buf.data());
   REQUIRE(line.find("Test PR") != std::string::npos);
   REQUIRE(line.find("o/r") != std::string::npos);
+
+  mvwinnstr(ui.help_win_, 3, 1, buf.data(), 79);
+  std::string help_line(buf.data());
+  REQUIRE(help_line.find("o - Open PR") != std::string::npos);
+  mvwinnstr(ui.help_win_, 4, 1, buf.data(), 79);
+  std::string help_line2(buf.data());
+  REQUIRE(help_line2.find("ENTER/d - Details") != std::string::npos);
 
   int prev_get = raw->get_count;
   ui.handle_key('r');

--- a/tests/test_tui_details.cpp
+++ b/tests/test_tui_details.cpp
@@ -1,0 +1,97 @@
+#include "github_poller.hpp"
+#define private public
+#include "tui.hpp"
+#undef private
+#include <array>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdio>
+#include <cstdlib>
+#if defined(_WIN32)
+#include <io.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#include <unistd.h>
+#endif
+#include <memory>
+
+using namespace agpm;
+
+class MockHttpClient : public HttpClient {
+public:
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "{}";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "{}";
+  }
+};
+
+TEST_CASE("tui show details") {
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  if (!isatty(fileno(stdout))) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
+
+  auto mock = std::make_unique<MockHttpClient>();
+  GitHubClient client({"token"}, std::move(mock));
+  GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
+  Tui ui(client, poller);
+  ui.init();
+  ui.update_prs({{1, "PR title", false, "o", "r"}});
+  ui.handle_key('d');
+  ui.draw();
+  std::array<char, 80> buf{};
+  mvwinnstr(ui.detail_win_, 2, 1, buf.data(), 79);
+  std::string detail(buf.data());
+  REQUIRE(detail.find("PR title") != std::string::npos);
+  ui.handle_key('d');
+  ui.cleanup();
+}
+
+TEST_CASE("tui show details enter") {
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  if (!isatty(fileno(stdout))) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
+
+  auto mock = std::make_unique<MockHttpClient>();
+  GitHubClient client({"token"}, std::move(mock));
+  GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
+  Tui ui(client, poller);
+  ui.init();
+  ui.update_prs({{2, "Another", false, "o", "r"}});
+  ui.handle_key('\n');
+  ui.draw();
+  std::array<char, 80> buf2{};
+  mvwinnstr(ui.detail_win_, 2, 1, buf2.data(), 79);
+  std::string detail2(buf2.data());
+  REQUIRE(detail2.find("Another") != std::string::npos);
+  ui.handle_key('\n');
+  ui.cleanup();
+}

--- a/tests/test_tui_open.cpp
+++ b/tests/test_tui_open.cpp
@@ -1,0 +1,69 @@
+#include "github_poller.hpp"
+#define private public
+#include "tui.hpp"
+#undef private
+#include <catch2/catch_test_macros.hpp>
+#include <cstdio>
+#include <cstdlib>
+#if defined(_WIN32)
+#include <io.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#include <unistd.h>
+#endif
+#include <memory>
+#include <string>
+
+using namespace agpm;
+
+class MockHttpClient : public HttpClient {
+public:
+  std::string get(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "{}";
+  }
+  std::string put(const std::string &url, const std::string &data,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)data;
+    (void)headers;
+    return "{}";
+  }
+  std::string del(const std::string &url,
+                  const std::vector<std::string> &headers) override {
+    (void)url;
+    (void)headers;
+    return "{}";
+  }
+};
+
+TEST_CASE("tui open pr") {
+#ifdef _WIN32
+  _putenv_s("TERM", "xterm");
+#else
+  setenv("TERM", "xterm", 1);
+#endif
+
+  if (!isatty(fileno(stdout))) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
+
+  auto mock = std::make_unique<MockHttpClient>();
+  GitHubClient client({"token"}, std::move(mock));
+  GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
+  Tui ui(client, poller);
+  ui.init();
+  ui.update_prs({{1, "PR", false, "o", "r"}});
+  std::string opened;
+  ui.open_cmd_ = [&](const std::string &url) {
+    opened = url;
+    return 0;
+  };
+  ui.handle_key('o');
+  REQUIRE(opened == "https://github.com/o/r/pull/1");
+  ui.cleanup();
+}


### PR DESCRIPTION
## Summary
- add hotkey to open selected PR in browser
- show PR details dialog with Enter or d
- document new hotkeys and add unit tests

## Testing
- `cmake --preset vcpkg` *(fails: openssl requires Linux kernel headers)*

------
https://chatgpt.com/codex/tasks/task_e_68acddbe68248325bb2b993a7cec5451