### PR TITLE
test: guard TUI resize test when no stdin tty

### DIFF
--- a/tests/test_tui_resize.cpp
+++ b/tests/test_tui_resize.cpp
@@ -46,7 +46,7 @@ TEST_CASE("test tui resize") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
+  if (!isatty(fileno(stdout)) || !isatty(fileno(stdin))) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }


### PR DESCRIPTION
## Summary
- skip TUI resize tests when stdin isn't a TTY to avoid segmentation faults on mac builds

## Testing
- `clang-tidy tests/test_tui_resize.cpp -p build/vcpkg` *(fails: Could not auto-detect compilation database)*
- `cmake --preset vcpkg` *(fails: openssl requires Linux kernel headers)*
- `ctest --preset vcpkg` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_68ace18e2e708325be8a2955cfb1a177