### PR TITLE
fix: stabilize poller shutdown and worker option

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -235,7 +235,7 @@ CliOptions parse_cli(int argc, char **argv) {
   app.add_option("--workers", options.workers, "Number of worker threads")
       ->type_name("N")
       ->check(CLI::PositiveNumber)
-      ->default_val("0")
+      ->default_val("1")
       ->group("Polling");
   app.add_option("--http-timeout", options.http_timeout,
                  "HTTP request timeout in seconds")

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -80,7 +80,7 @@ void Poller::worker() {
     {
       std::unique_lock<std::mutex> lock(mutex_);
       cv_.wait(lock, [this] { return !running_ || !jobs_.empty(); });
-      if (!running_ && jobs_.empty())
+      if (!running_)
         return;
       job = std::move(jobs_.front());
       jobs_.pop();


### PR DESCRIPTION
## Summary
- ensure poller stops without executing queued jobs
- default CLI worker count to 1 to satisfy validation

## Testing
- `scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*
- `scripts/install_linux.sh` *(partial; installing dependencies but heavy)*

------
https://chatgpt.com/codex/tasks/task_e_68adf82221d48325a6deaaf3a9e459e9