### PR TITLE
fix(cli): ensure argv vector is null-terminated

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -322,7 +322,9 @@ CliOptions parse_cli(int argc, char **argv) {
                "Only purge branches and skip PR polling")
       ->group("Actions");
   try {
-    app.parse(argc, argv);
+    std::vector<char *> args(argv, argv + argc);
+    args.push_back(nullptr);
+    app.parse(argc, args.data());
   } catch (const CLI::ParseError &e) {
     throw std::runtime_error(e.what());
   }


### PR DESCRIPTION
## Summary
- ensure CLI argv array is null-terminated before parsing

## Testing
- `ctest --preset vcpkg` *(failed: hung with no output)*

------
https://chatgpt.com/codex/tasks/task_e_68ae016a004c8325acdb52d04c6e8d80