### PR TITLE
fix: ensure curl error test avoids DNS resolution

### DIFF
--- a/tests/test_github_client_delay.cpp
+++ b/tests/test_github_client_delay.cpp
@@ -55,12 +55,12 @@ TEST_CASE("test github client delay") {
 
   try {
     CurlHttpClient real;
-    real.get("https://nonexistent.invalid", {});
+    real.get("http://192.0.2.1/", {});
     FAIL("Expected exception");
   } catch (const std::exception &e) {
     std::string msg = e.what();
-    REQUIRE(msg.find("nonexistent.invalid") != std::string::npos);
-    REQUIRE(msg.find(curl_easy_strerror(CURLE_COULDNT_RESOLVE_HOST)) !=
+    REQUIRE(msg.find("192.0.2.1") != std::string::npos);
+    REQUIRE(msg.find(curl_easy_strerror(CURLE_COULDNT_CONNECT)) !=
             std::string::npos);
   }
 }


### PR DESCRIPTION
## Summary
- avoid DNS lookups in CurlHttpClient error test by using a reserved IP

## Testing
- `cmake --preset vcpkg` *(fails: building curl dependency; process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68aecbcd38348325899ed5c4d038002e