### PR TITLE
docs: document rate limiting and branch protections

### DIFF
--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -92,6 +92,70 @@ Branches that have diverged from their remote are considered dirty and are
 skipped by default. Pass `--reject-dirty` to close these branches
 automatically, overriding the protection for dirty branches.
 
+## Rate Limiting
+
+Use `--max-request-rate` to throttle GitHub API calls. This option limits how
+many requests are issued per minute to avoid hitting GitHub's API quotas.
+
+YAML:
+```yaml
+max_request_rate: 60
+```
+
+JSON:
+```json
+{
+  "max_request_rate": 60
+}
+```
+
+## Branch Protection Patterns
+
+Glob patterns can designate branches that must never be modified. Provide
+patterns with `--protect-branch` and use `--protect-branch-exclude` to remove
+protection for specific names.
+
+YAML:
+```yaml
+protected_branches:
+  - main
+  - release/*
+protected_branch_excludes:
+  - release/temp/*
+```
+
+JSON:
+```json
+{
+  "protected_branches": ["main", "release/*"],
+  "protected_branch_excludes": ["release/temp/*"]
+}
+```
+
+## Dry-Run and Proxy Support
+
+`--dry-run` simulates operations without altering repositories. HTTP requests
+may be routed through proxies using `--http-proxy` and `--https-proxy`.
+
+CLI:
+```bash
+autogithubpullmerge --dry-run --http-proxy http://proxy --https-proxy http://secureproxy
+```
+
+YAML:
+```yaml
+http_proxy: http://proxy
+https_proxy: http://secureproxy
+```
+
+JSON:
+```json
+{
+  "http_proxy": "http://proxy",
+  "https_proxy": "http://secureproxy"
+}
+```
+
 ## Configuration File Examples
 
 YAML:

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ A cross-platform tool to manage and monitor GitHub pull requests from a terminal
 - CLI options for GitHub API keys (`--api-key`, `--api-key-from-stream`,
   `--api-key-url`, `--api-key-url-user`, `--api-key-url-password`,
   `--api-key-file`)
+- Rate limiting to control GitHub API usage
+- Branch protection patterns to guard important branches
+- Dry-run mode and HTTP/HTTPS proxy support
 
 ## Building (Linux)
 ```bash
@@ -187,6 +190,64 @@ Destructive options (`--reject-dirty`, `--auto-merge`, `--purge-prefix`,
 These options may also be specified in JSON or YAML configuration files as
 `http_timeout`, `http_retries`, `download_limit`, `upload_limit`,
 `max_download` and `max_upload`.
+
+## Rate Limiting
+
+The `--max-request-rate` option throttles how many GitHub API calls are made
+per minute to stay within rate limits.
+
+```yaml
+max_request_rate: 60
+```
+
+```json
+{
+  "max_request_rate": 60
+}
+```
+
+## Branch Protection Patterns
+
+Glob patterns supplied with `--protect-branch` define branches that must not be
+modified. Patterns passed via `--protect-branch-exclude` remove protection for
+matching names.
+
+```yaml
+protected_branches:
+  - main
+  - release/*
+protected_branch_excludes:
+  - release/temp/*
+```
+
+```json
+{
+  "protected_branches": ["main", "release/*"],
+  "protected_branch_excludes": ["release/temp/*"]
+}
+```
+
+## Dry-Run and Proxy Support
+
+Use `--dry-run` to simulate operations without altering repositories. HTTP
+requests may be routed through proxies using `--http-proxy` and
+`--https-proxy`.
+
+```bash
+autogithubpullmerge --dry-run --http-proxy http://proxy --https-proxy http://secureproxy
+```
+
+```yaml
+http_proxy: http://proxy
+https_proxy: http://secureproxy
+```
+
+```json
+{
+  "http_proxy": "http://proxy",
+  "https_proxy": "http://secureproxy"
+}
+```
 
 ## TUI Hotkeys
 


### PR DESCRIPTION
## Summary
- document rate limiting configuration
- outline branch protection patterns
- explain dry-run and proxy options

## Testing
- `cmake --preset vcpkg` *(fails: requires extensive vcpkg build)*
- `ctest --preset vcpkg` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17dcb8c9483259e8e4bf5b233f721