### PR TITLE
fix: resolve mac member initialization warning

### DIFF
--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -20,10 +20,10 @@ GitHubPoller::GitHubPoller(
       only_poll_stray_(only_poll_stray), reject_dirty_(reject_dirty),
       purge_prefix_(std::move(purge_prefix)), auto_merge_(auto_merge),
       purge_only_(purge_only), sort_mode_(std::move(sort_mode)),
-      dry_run_(dry_run), history_(history),
+      dry_run_(dry_run), graphql_client_(graphql_client),
       protected_branches_(std::move(protected_branches)),
       protected_branch_excludes_(std::move(protected_branch_excludes)),
-      graphql_client_(graphql_client) {}
+      history_(history) {}
 
 void GitHubPoller::start() {
   spdlog::info("Starting GitHub poller");


### PR DESCRIPTION
## Summary
- reorder GitHubPoller member initialization to match declaration order and resolve mac build warning

## Testing
- `cmake .. -DBUILD_TESTING=ON` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17e2d70288325a1da24dcf15bc38e