### PR TITLE
fix: skip tui tests when terminal unavailable

### DIFF
--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -60,11 +60,6 @@ TEST_CASE("test tui") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   mock->get_response = "[{\"number\":1,\"title\":\"Test PR\"}]";
   mock->put_response = "{\"merged\":true}";
@@ -73,6 +68,10 @@ TEST_CASE("test tui") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
 
   ui.update_prs({{1, "Test PR", false, "o", "r"}});
   ui.draw();

--- a/tests/test_tui_details.cpp
+++ b/tests/test_tui_details.cpp
@@ -47,16 +47,15 @@ TEST_CASE("tui show details") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
   ui.update_prs({{1, "PR title", false, "o", "r"}});
   ui.handle_key('d');
   ui.draw();
@@ -75,16 +74,15 @@ TEST_CASE("tui show details enter") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
   ui.update_prs({{2, "Another", false, "o", "r"}});
   ui.handle_key('\n');
   ui.draw();

--- a/tests/test_tui_log_limit.cpp
+++ b/tests/test_tui_log_limit.cpp
@@ -54,16 +54,16 @@ TEST_CASE("test tui log limit") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   mock->put_response = "{\"merged\":true}";
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
+  ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
 
   for (int i = 0; i < 205; ++i) {
     ui.update_prs({{i, "PR", false, "o", "r"}});

--- a/tests/test_tui_merge.cpp
+++ b/tests/test_tui_merge.cpp
@@ -54,11 +54,6 @@ TEST_CASE("test tui merge") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   mock->get_response = "[{\"number\":1,\"title\":\"PR\"}]";
   mock->put_response = "{\"merged\":true}";
@@ -67,6 +62,10 @@ TEST_CASE("test tui merge") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
 
   auto prs = client.list_pull_requests("o", "r");
   ui.update_prs(prs);

--- a/tests/test_tui_open.cpp
+++ b/tests/test_tui_open.cpp
@@ -47,16 +47,15 @@ TEST_CASE("tui open pr") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
   ui.update_prs({{1, "PR", false, "o", "r"}});
   std::string opened;
   ui.open_cmd_ = [&](const std::string &url) {

--- a/tests/test_tui_resize.cpp
+++ b/tests/test_tui_resize.cpp
@@ -46,16 +46,15 @@ TEST_CASE("test tui resize") {
   setenv("TERM", "xterm", 1);
 #endif
 
-  if (!isatty(fileno(stdout)) || !isatty(fileno(stdin))) {
-    WARN("Skipping TUI test: no TTY available");
-    return;
-  }
-
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
+  if (!ui.initialized_) {
+    WARN("Skipping TUI test: no TTY available");
+    return;
+  }
 
   ui.update_prs({{1, "PR", false, "o", "r"}});
   ui.draw();


### PR DESCRIPTION
## Summary
- guard TUI unit tests by verifying curses initialization and skipping when no TTY is available

## Testing
- `cmake .. && make && ctest` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17e2d70288325a1da24dcf15bc38e