### PR TITLE
feat(cli): allow zero workers sentinel

### DIFF
--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -234,8 +234,7 @@ CliOptions parse_cli(int argc, char **argv) {
       ->group("Polling");
   app.add_option("--workers", options.workers, "Number of worker threads")
       ->type_name("N")
-      ->check(CLI::PositiveNumber)
-      ->default_val("1")
+      ->check(CLI::NonNegativeNumber)
       ->group("Polling");
   app.add_option("--http-timeout", options.http_timeout,
                  "HTTP request timeout in seconds")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,7 @@ int main(int argc, char **argv) {
     bool auto_merge = opts.auto_merge || cfg.auto_merge();
     bool purge_only = opts.purge_only || cfg.purge_only();
     std::string sort_mode = !opts.sort.empty() ? opts.sort : cfg.sort_mode();
-    int workers = opts.workers != 0 ? opts.workers : cfg.workers();
+    int workers = opts.workers == 0 ? cfg.workers() : opts.workers;
     if (workers <= 0)
       workers = 1;
 

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -266,6 +266,29 @@ TEST_CASE("test cli") {
   REQUIRE(opts_proxy.http_proxy == "http://proxy");
   REQUIRE(opts_proxy.https_proxy == "http://secureproxy");
 
+  char workers_flag[] = "--workers";
+  char workers_val[] = "4";
+  char *argv_workers[] = {prog, workers_flag, workers_val};
+  agpm::CliOptions opts_workers = agpm::parse_cli(3, argv_workers);
+  REQUIRE(opts_workers.workers == 4);
+
+  char workers_zero[] = "0";
+  char *argv_workers_zero[] = {prog, workers_flag, workers_zero};
+  agpm::CliOptions opts_workers_zero = agpm::parse_cli(3, argv_workers_zero);
+  REQUIRE(opts_workers_zero.workers == 0);
+
+  {
+    char workers_neg[] = "-1";
+    char *argv_workers_neg[] = {prog, workers_flag, workers_neg};
+    bool threw = false;
+    try {
+      agpm::parse_cli(3, argv_workers_neg);
+    } catch (const std::exception &) {
+      threw = true;
+    }
+    REQUIRE(threw);
+  }
+
   {
     char bad[] = "--unknown";
     char *argv_bad[] = {prog, bad};


### PR DESCRIPTION
## Summary
- allow `--workers` to accept zero and no default
- fall back to config only when CLI workers is zero
- cover workers flag edge cases in CLI tests

## Testing
- `scripts/build_linux.sh` *(fails: struct __xfer_bufptrs redeclared with different access)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ad82a0bc8325a5356c51f03d5d66