### PR TITLE
feat: add GraphQL option to configuration

### DIFF
--- a/examples/config.json
+++ b/examples/config.json
@@ -1,5 +1,6 @@
 {
   "verbose": false,
   "poll_interval": 30,
-  "max_request_rate": 50
+  "max_request_rate": 50,
+  "use_graphql": true
 }

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -2,3 +2,5 @@
 verbose: true
 poll_interval: 60
 max_request_rate: 100
+use_graphql: true
+

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -276,6 +276,12 @@ public:
   /// Set sorting mode for pull request listing.
   void set_sort_mode(const std::string &mode) { sort_mode_ = mode; }
 
+  /// Use the GraphQL API for pull request queries.
+  bool use_graphql() const { return use_graphql_; }
+
+  /// Enable or disable GraphQL usage.
+  void set_use_graphql(bool v) { use_graphql_ = v; }
+
   /// Load configuration from the file at `path`.
   static Config from_file(const std::string &path);
 
@@ -317,6 +323,7 @@ private:
   int pr_limit_ = 50;
   std::chrono::seconds pr_since_{0};
   std::string sort_mode_;
+  bool use_graphql_ = false;
   int http_timeout_ = 30;
   int http_retries_ = 3;
   std::string api_base_ = "https://api.github.com";

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -186,6 +186,9 @@ void Config::load_json(const nlohmann::json &j) {
   if (j.contains("sort")) {
     set_sort_mode(j["sort"].get<std::string>());
   }
+  if (j.contains("use_graphql")) {
+    set_use_graphql(j["use_graphql"].get<bool>());
+  }
 
   // Warn on repositories appearing in both include and exclude lists.
   if (!include_repos_.empty() && !exclude_repos_.empty()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -121,7 +121,8 @@ int main(int argc, char **argv) {
         client, repos, interval_ms, max_rate, workers, only_poll_prs,
         only_poll_stray, reject_dirty, purge_prefix, auto_merge, purge_only,
         sort_mode, &history, protected_branches, protected_branch_excludes,
-        opts.dry_run, opts.use_graphql ? &graphql_client : nullptr);
+        opts.dry_run,
+        (opts.use_graphql || cfg.use_graphql()) ? &graphql_client : nullptr);
 
     if (!opts.export_csv.empty() || !opts.export_json.empty()) {
       poller.set_export_callback([&history, &opts]() {

--- a/tests/test_config_from_json.cpp
+++ b/tests/test_config_from_json.cpp
@@ -19,6 +19,7 @@ TEST_CASE("test config from json") {
   j["max_upload"] = 1011;
   j["http_proxy"] = "http://proxy";
   j["https_proxy"] = "http://secureproxy";
+  j["use_graphql"] = true;
 
   agpm::Config cfg = agpm::Config::from_json(j);
 
@@ -36,4 +37,5 @@ TEST_CASE("test config from json") {
   REQUIRE(cfg.max_upload() == 1011);
   REQUIRE(cfg.http_proxy() == "http://proxy");
   REQUIRE(cfg.https_proxy() == "http://secureproxy");
+  REQUIRE(cfg.use_graphql());
 }

--- a/tests/test_config_loading.cpp
+++ b/tests/test_config_loading.cpp
@@ -17,6 +17,7 @@ TEST_CASE("test config loading") {
     f << "max_upload: 14\n";
     f << "http_proxy: http://proxy\n";
     f << "https_proxy: http://secureproxy\n";
+    f << "use_graphql: true\n";
     f.close();
   }
   agpm::Config ycfg = agpm::Config::from_file("config.yaml");
@@ -32,6 +33,7 @@ TEST_CASE("test config loading") {
   REQUIRE(ycfg.max_upload() == 14);
   REQUIRE(ycfg.http_proxy() == "http://proxy");
   REQUIRE(ycfg.https_proxy() == "http://secureproxy");
+  REQUIRE(ycfg.use_graphql());
 
   {
     std::ofstream f("config.json");
@@ -47,7 +49,8 @@ TEST_CASE("test config loading") {
     f << "\"max_download\":23,";
     f << "\"max_upload\":24,";
     f << "\"http_proxy\":\"http://proxy\",";
-    f << "\"https_proxy\":\"http://secureproxy\"";
+    f << "\"https_proxy\":\"http://secureproxy\",";
+    f << "\"use_graphql\":false";
     f << "}";
     f.close();
   }
@@ -64,4 +67,5 @@ TEST_CASE("test config loading") {
   REQUIRE(jcfg.max_upload() == 24);
   REQUIRE(jcfg.http_proxy() == "http://proxy");
   REQUIRE(jcfg.https_proxy() == "http://secureproxy");
+  REQUIRE(!jcfg.use_graphql());
 }

--- a/tests/test_main_graphql.cpp
+++ b/tests/test_main_graphql.cpp
@@ -1,0 +1,41 @@
+#include "app.hpp"
+#include "config.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <fstream>
+#include <vector>
+
+TEST_CASE("use_graphql honored in main") {
+  SECTION("enabled via CLI") {
+    agpm::App app;
+    std::vector<char *> args;
+    char prog[] = "tests";
+    char flag[] = "--use-graphql";
+    args.push_back(prog);
+    args.push_back(flag);
+    REQUIRE(app.run(static_cast<int>(args.size()), args.data()) == 0);
+    const auto &opts = app.options();
+    const auto &cfg = app.config();
+    bool use_graphql = opts.use_graphql || cfg.use_graphql();
+    REQUIRE(use_graphql);
+  }
+
+  SECTION("enabled via config file") {
+    agpm::App app;
+    std::ofstream f("graphql_config.yaml");
+    f << "use_graphql: true\n";
+    f.close();
+    std::vector<char *> args;
+    char prog[] = "tests";
+    char cflag[] = "--config";
+    char file[] = "graphql_config.yaml";
+    args.push_back(prog);
+    args.push_back(cflag);
+    args.push_back(file);
+    REQUIRE(app.run(static_cast<int>(args.size()), args.data()) == 0);
+    const auto &opts = app.options();
+    const auto &cfg = app.config();
+    REQUIRE(cfg.use_graphql());
+    bool use_graphql = opts.use_graphql || cfg.use_graphql();
+    REQUIRE(use_graphql);
+  }
+}


### PR DESCRIPTION
## Summary
- add `use_graphql` setting with getters/setters
- parse `use_graphql` from config files
- enable GraphQL when requested by CLI or config
- cover GraphQL option with JSON/YAML and main tests

## Testing
- `cmake -S . -B build` *(fails: building dependencies did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b702ca3c8325b20844ad00446635