### PR TITLE
fix: expose CurlHttpClient config for tests

### DIFF
--- a/include/github_client.hpp
+++ b/include/github_client.hpp
@@ -138,6 +138,24 @@ public:
   /// Total bytes uploaded so far.
   curl_off_t total_uploaded() const { return total_uploaded_; }
 
+  /// Download limit in bytes per second.
+  curl_off_t download_limit() const { return download_limit_; }
+
+  /// Upload limit in bytes per second.
+  curl_off_t upload_limit() const { return upload_limit_; }
+
+  /// Maximum cumulative download in bytes.
+  curl_off_t max_download() const { return max_download_; }
+
+  /// Maximum cumulative upload in bytes.
+  curl_off_t max_upload() const { return max_upload_; }
+
+  /// HTTP proxy URL.
+  const std::string &http_proxy() const { return http_proxy_; }
+
+  /// HTTPS proxy URL.
+  const std::string &https_proxy() const { return https_proxy_; }
+
 private:
   void apply_proxy(CURL *curl, const std::string &url);
   CurlHandle curl_;

--- a/tests/test_curl_http_client.cpp
+++ b/tests/test_curl_http_client.cpp
@@ -1,6 +1,4 @@
-#define private public
 #include "github_client.hpp"
-#undef private
 #include <catch2/catch_test_macros.hpp>
 #include <curl/curl.h>
 #include <string>
@@ -16,10 +14,10 @@ TEST_CASE("CurlHttpClient configuration") {
   std::string https_proxy = "http://secureproxy";
   CurlHttpClient client(1000, download_limit, upload_limit, max_download,
                         max_upload, http_proxy, https_proxy);
-  REQUIRE(client.download_limit_ == download_limit);
-  REQUIRE(client.upload_limit_ == upload_limit);
-  REQUIRE(client.max_download_ == max_download);
-  REQUIRE(client.max_upload_ == max_upload);
-  REQUIRE(client.http_proxy_ == http_proxy);
-  REQUIRE(client.https_proxy_ == https_proxy);
+  REQUIRE(client.download_limit() == download_limit);
+  REQUIRE(client.upload_limit() == upload_limit);
+  REQUIRE(client.max_download() == max_download);
+  REQUIRE(client.max_upload() == max_upload);
+  REQUIRE(client.http_proxy() == http_proxy);
+  REQUIRE(client.https_proxy() == https_proxy);
 }


### PR DESCRIPTION
## Summary
- add getter methods to CurlHttpClient for configuration fields
- use getters in tests instead of redefining `private` macro

## Testing
- `cmake --preset vcpkg` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e8c7b85c8325bb4f9a770a55f055