### PR TITLE
docs: document branch protection options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,14 +211,15 @@ max_request_rate: 60
 `--protect-branch` marks branches that must not be modified. Use
 `--protect-branch-exclude` to remove protection for matching patterns.
 Patterns support glob or regular expression syntax, and exclude patterns take
-precedence over protections.
+precedence over protections. Regular expressions should be provided without
+surrounding delimiters, for example `^hotfix-[0-9]+$`.
 
 ### Command Line
 
 ```bash
 autogithubpullmerge --protect-branch main \
   --protect-branch 'release/*' \
-  --protect-branch '/^hotfix-[0-9]+/' \
+  --protect-branch '^hotfix-[0-9]+$' \
   --protect-branch-exclude 'release/temp/*'
 ```
 
@@ -228,14 +229,14 @@ autogithubpullmerge --protect-branch main \
 protected_branches:
   - main
   - release/*
-  - '/^hotfix-[0-9]+/'
+  - '^hotfix-[0-9]+$'
 protected_branch_excludes:
   - release/temp/*
 ```
 
 ```json
 {
-  "protected_branches": ["main", "release/*", "/^hotfix-[0-9]+/"],
+  "protected_branches": ["main", "release/*", "^hotfix-[0-9]+$"],
   "protected_branch_excludes": ["release/temp/*"]
 }
 ```

--- a/readme.md
+++ b/readme.md
@@ -208,21 +208,34 @@ max_request_rate: 60
 
 ## Branch Protection Patterns
 
-Glob patterns supplied with `--protect-branch` define branches that must not be
-modified. Patterns passed via `--protect-branch-exclude` remove protection for
-matching names.
+`--protect-branch` marks branches that must not be modified. Use
+`--protect-branch-exclude` to remove protection for matching patterns.
+Patterns support glob or regular expression syntax, and exclude patterns take
+precedence over protections.
+
+### Command Line
+
+```bash
+autogithubpullmerge --protect-branch main \
+  --protect-branch 'release/*' \
+  --protect-branch '/^hotfix-[0-9]+/' \
+  --protect-branch-exclude 'release/temp/*'
+```
+
+### Configuration
 
 ```yaml
 protected_branches:
   - main
   - release/*
+  - '/^hotfix-[0-9]+/'
 protected_branch_excludes:
   - release/temp/*
 ```
 
 ```json
 {
-  "protected_branches": ["main", "release/*"],
+  "protected_branches": ["main", "release/*", "/^hotfix-[0-9]+/"],
   "protected_branch_excludes": ["release/temp/*"]
 }
 ```


### PR DESCRIPTION
## Summary
- describe `--protect-branch` and `--protect-branch-exclude`
- note glob/regex support and exclusion precedence
- provide CLI and configuration examples

## Testing
- `make build` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e895fe1883258519766bdbe76e4b