### PR TITLE
fix: expose tui internals for testing

### DIFF
--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -15,6 +15,7 @@
 #include "github_poller.hpp"
 #include <functional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace agpm {
@@ -60,6 +61,31 @@ public:
 
   /// Access collected log messages.
   const std::vector<std::string> &logs() const { return logs_; }
+
+  /**
+   * Check whether the TUI has been successfully initialized.
+   *
+   * @return true if curses has been initialized and windows created
+   */
+  bool initialized() const { return initialized_; }
+
+  /// Access the main pull request window (primarily for tests).
+  WINDOW *pr_win() const { return pr_win_; }
+
+  /// Access the help window (primarily for tests).
+  WINDOW *help_win() const { return help_win_; }
+
+  /// Access the detail window (primarily for tests).
+  WINDOW *detail_win() const { return detail_win_; }
+
+  /**
+   * Override the command used to open URLs. Intended for tests.
+   *
+   * @param cmd Function returning the exit code after opening the URL
+   */
+  void set_open_cmd(std::function<int(const std::string &)> cmd) {
+    open_cmd_ = std::move(cmd);
+  }
 
 private:
   void log(const std::string &msg);

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -1,7 +1,5 @@
 #include "github_poller.hpp"
-#define private public
 #include "tui.hpp"
-#undef private
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
@@ -68,7 +66,7 @@ TEST_CASE("test tui") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }
@@ -81,10 +79,10 @@ TEST_CASE("test tui") {
   REQUIRE(line.find("Test PR") != std::string::npos);
   REQUIRE(line.find("o/r") != std::string::npos);
 
-  mvwinnstr(ui.help_win_, 3, 1, buf.data(), 79);
+  mvwinnstr(ui.help_win(), 3, 1, buf.data(), 79);
   std::string help_line(buf.data());
   REQUIRE(help_line.find("o - Open PR") != std::string::npos);
-  mvwinnstr(ui.help_win_, 4, 1, buf.data(), 79);
+  mvwinnstr(ui.help_win(), 4, 1, buf.data(), 79);
   std::string help_line2(buf.data());
   REQUIRE(help_line2.find("ENTER/d - Details") != std::string::npos);
 

--- a/tests/test_tui_details.cpp
+++ b/tests/test_tui_details.cpp
@@ -1,7 +1,5 @@
 #include "github_poller.hpp"
-#define private public
 #include "tui.hpp"
-#undef private
 #include <array>
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
@@ -52,7 +50,7 @@ TEST_CASE("tui show details") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }
@@ -60,7 +58,7 @@ TEST_CASE("tui show details") {
   ui.handle_key('d');
   ui.draw();
   std::array<char, 80> buf{};
-  mvwinnstr(ui.detail_win_, 2, 1, buf.data(), 79);
+  mvwinnstr(ui.detail_win(), 2, 1, buf.data(), 79);
   std::string detail(buf.data());
   REQUIRE(detail.find("PR title") != std::string::npos);
   ui.handle_key('d');
@@ -79,7 +77,7 @@ TEST_CASE("tui show details enter") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }
@@ -87,7 +85,7 @@ TEST_CASE("tui show details enter") {
   ui.handle_key('\n');
   ui.draw();
   std::array<char, 80> buf2{};
-  mvwinnstr(ui.detail_win_, 2, 1, buf2.data(), 79);
+  mvwinnstr(ui.detail_win(), 2, 1, buf2.data(), 79);
   std::string detail2(buf2.data());
   REQUIRE(detail2.find("Another") != std::string::npos);
   ui.handle_key('\n');

--- a/tests/test_tui_log_limit.cpp
+++ b/tests/test_tui_log_limit.cpp
@@ -60,7 +60,7 @@ TEST_CASE("test tui log limit") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }

--- a/tests/test_tui_merge.cpp
+++ b/tests/test_tui_merge.cpp
@@ -62,7 +62,7 @@ TEST_CASE("test tui merge") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }

--- a/tests/test_tui_open.cpp
+++ b/tests/test_tui_open.cpp
@@ -1,7 +1,5 @@
 #include "github_poller.hpp"
-#define private public
 #include "tui.hpp"
-#undef private
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
 #include <cstdlib>
@@ -52,16 +50,16 @@ TEST_CASE("tui open pr") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }
   ui.update_prs({{1, "PR", false, "o", "r"}});
   std::string opened;
-  ui.open_cmd_ = [&](const std::string &url) {
+  ui.set_open_cmd([&](const std::string &url) {
     opened = url;
     return 0;
-  };
+  });
   ui.handle_key('o');
   REQUIRE(opened == "https://github.com/o/r/pull/1");
   ui.cleanup();

--- a/tests/test_tui_resize.cpp
+++ b/tests/test_tui_resize.cpp
@@ -1,7 +1,5 @@
 #include "github_poller.hpp"
-#define private public
 #include "tui.hpp"
-#undef private
 #include <catch2/catch_test_macros.hpp>
 #include <cstdio>
 #include <cstdlib>
@@ -51,18 +49,18 @@ TEST_CASE("test tui resize") {
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
   Tui ui(client, poller);
   ui.init();
-  if (!ui.initialized_) {
+  if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
     return;
   }
 
   ui.update_prs({{1, "PR", false, "o", "r"}});
   ui.draw();
-  WINDOW *before = ui.pr_win_;
+  WINDOW *before = ui.pr_win();
   int h, w;
   getmaxyx(stdscr, h, w);
   resize_term(h / 2, w / 2);
   ui.draw();
-  REQUIRE(before != ui.pr_win_);
+  REQUIRE(before != ui.pr_win());
   ui.cleanup();
 }


### PR DESCRIPTION
## Summary
- add TUI accessors for initialization, window pointers, and open command override
- update TUI tests to use public APIs instead of redefining `private`

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON && cmake --build build && ctest --test-dir build` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b56dc3446083259abf01f17a625735