### PR TITLE
feat: add cross-platform notification support

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -12,8 +12,16 @@ auto notifier = std::make_shared<agpm::NotifySendNotifier>();
 poller.set_notifier(notifier);
 ```
 
-`NotifySendNotifier` uses the `notify-send` command available on many Linux
-systems to display desktop notifications. Other platforms ignore the call.
+`NotifySendNotifier` attempts to surface desktop notifications on the host
+platform:
+
+- **Linux** – uses `notify-send` when available.
+- **Windows** – uses PowerShell's `New-BurntToastNotification` if the
+  BurntToast module is installed.
+- **macOS** – prefers `terminal-notifier` and falls back to `osascript`.
+
+If none of the required utilities are present, the notification request is
+silently ignored.
 
 ## Extending
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -20,8 +20,8 @@ platform:
   BurntToast module is installed.
 - **macOS** – prefers `terminal-notifier` and falls back to `osascript`.
 
-If none of the required utilities are present, the notification request is
-silently ignored.
+All message text is escaped before invoking external commands. If none of the
+required utilities are present, the notification request is silently ignored.
 
 ## Extending
 

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -38,8 +38,6 @@ std::string escape_powershell(const std::string &s) {
   for (char c : s) {
     if (c == '\'') {
       out += "''";
-    } else if (c == '"') {
-      out += "\\\"";
     } else {
       out.push_back(c);
     }

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -3,29 +3,76 @@
 
 namespace agpm {
 
+namespace {
+
+std::string shell_escape(const std::string &s) {
+  std::string out;
+  out.reserve(s.size() + 2);
+  out.push_back('\'');
+  for (char c : s) {
+    if (c == '\'') {
+      out += "'\\''";
+    } else {
+      out.push_back(c);
+    }
+  }
+  out.push_back('\'');
+  return out;
+}
+
+std::string escape_apple_script(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    if (c == '\\' || c == '"') {
+      out.push_back('\\');
+    }
+    out.push_back(c);
+  }
+  return out;
+}
+
+std::string escape_powershell(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    if (c == '\'') {
+      out += "''";
+    } else if (c == '"') {
+      out += "\\\"";
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+} // namespace
+
 void NotifySendNotifier::notify(const std::string &message) {
 #ifdef _WIN32
   std::string cmd =
       "powershell -NoProfile -Command \"Try {Import-Module BurntToast "
-      "-ErrorAction "
-      "Stop; New-BurntToastNotification -Text 'autogithubpullmerge','" +
-      message + "'} Catch {}\"";
+      "-ErrorAction Stop; New-BurntToastNotification -Text "
+      "'autogithubpullmerge','" +
+      escape_powershell(message) + "'} Catch {}\"";
   std::system(cmd.c_str());
 #elif __APPLE__
   if (std::system("command -v terminal-notifier >/dev/null 2>&1") == 0) {
     std::string cmd =
-        "terminal-notifier -title 'autogithubpullmerge' -message '" + message +
-        "'";
+        "terminal-notifier -title 'autogithubpullmerge' -message " +
+        shell_escape(message);
     std::system(cmd.c_str());
   } else {
-    std::string cmd = "osascript -e 'display notification \"";
-    cmd += message;
-    cmd += "\" with title \"autogithubpullmerge\"'";
+    std::string cmd = "osascript -e 'display notification \"" +
+                      escape_apple_script(message) +
+                      "\" with title \"autogithubpullmerge\"'";
     std::system(cmd.c_str());
   }
 #elif __linux__
   if (std::system("command -v notify-send >/dev/null 2>&1") == 0) {
-    std::string cmd = "notify-send \"autogithubpullmerge\" \"" + message + "\"";
+    std::string cmd = "notify-send " + shell_escape("autogithubpullmerge") +
+                      " " + shell_escape(message);
     std::system(cmd.c_str());
   }
 #else

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -18,8 +18,9 @@ void NotifySendNotifier::notify(const std::string &message) {
         "'";
     std::system(cmd.c_str());
   } else {
-    std::string cmd = "osascript -e 'display notification \"" + message +
-                      "\" with title \"autogithubpullmerge\"'";
+    std::string cmd = "osascript -e 'display notification \"";
+    cmd += message;
+    cmd += "\" with title \"autogithubpullmerge\"'";
     std::system(cmd.c_str());
   }
 #elif __linux__

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -4,9 +4,29 @@
 namespace agpm {
 
 void NotifySendNotifier::notify(const std::string &message) {
-#ifdef __linux__
-  std::string cmd = "notify-send \"autogithubpullmerge\" \"" + message + "\"";
+#ifdef _WIN32
+  std::string cmd =
+      "powershell -NoProfile -Command \"Try {Import-Module BurntToast "
+      "-ErrorAction "
+      "Stop; New-BurntToastNotification -Text 'autogithubpullmerge','" +
+      message + "'} Catch {}\"";
   std::system(cmd.c_str());
+#elif __APPLE__
+  if (std::system("command -v terminal-notifier >/dev/null 2>&1") == 0) {
+    std::string cmd =
+        "terminal-notifier -title 'autogithubpullmerge' -message '" + message +
+        "'";
+    std::system(cmd.c_str());
+  } else {
+    std::string cmd = "osascript -e 'display notification \"" + message +
+                      "\" with title \"autogithubpullmerge\"'";
+    std::system(cmd.c_str());
+  }
+#elif __linux__
+  if (std::system("command -v notify-send >/dev/null 2>&1") == 0) {
+    std::string cmd = "notify-send \"autogithubpullmerge\" \"" + message + "\"";
+    std::system(cmd.c_str());
+  }
 #else
   (void)message;
 #endif


### PR DESCRIPTION
## Summary
- add Windows and macOS notification implementations with fallbacks
- document platform-specific notification behavior

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e69e82f48325bd918afbee8c7372