### PR TITLE
feat: make TUI log limit configurable

### DIFF
--- a/include/cli.hpp
+++ b/include/cli.hpp
@@ -13,6 +13,7 @@ struct CliOptions {
   std::string config_file;        ///< Optional path to configuration file
   std::string log_level = "info"; ///< Logging verbosity level
   std::string log_file;           ///< Optional path to rotating log file
+  int log_limit{200};             ///< Maximum number of log messages to retain
   bool assume_yes{false};         ///< Skip confirmation prompts
   bool dry_run{false};            ///< Simulate operations without changes
   std::vector<std::string> include_repos; ///< Repositories to include

--- a/include/tui.hpp
+++ b/include/tui.hpp
@@ -13,6 +13,7 @@
 
 #include "github_client.hpp"
 #include "github_poller.hpp"
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <utility>
@@ -28,10 +29,11 @@ public:
   /**
    * Construct a TUI bound to a GitHub client and poller.
    *
-   * @param client GitHub API client used for interactive actions
-   * @param poller Poller providing periodic updates
+   * @param client    GitHub API client used for interactive actions
+   * @param poller    Poller providing periodic updates
+   * @param log_limit Maximum number of log messages to keep in memory
    */
-  Tui(GitHubClient &client, GitHubPoller &poller);
+  Tui(GitHubClient &client, GitHubPoller &poller, std::size_t log_limit = 200);
 
   /// Initialize the curses library and windows.
   void init();
@@ -94,6 +96,7 @@ private:
   GitHubPoller &poller_;
   std::vector<PullRequest> prs_;
   std::vector<std::string> logs_;
+  std::size_t log_limit_;
   int selected_{0};
   WINDOW *pr_win_{nullptr};
   WINDOW *log_win_{nullptr};

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -151,6 +151,11 @@ CliOptions parse_cli(int argc, char **argv) {
   app.add_option("--log-file", options.log_file, "Path to rotating log file")
       ->type_name("FILE")
       ->group("General");
+  app.add_option("--log-limit", options.log_limit,
+                 "Maximum number of log messages to retain")
+      ->type_name("N")
+      ->default_val("200")
+      ->group("General");
   app.add_flag("-y,--yes", options.assume_yes,
                "Assume yes to confirmation prompts")
       ->group("General");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv) {
         }
       });
     }
-    agpm::Tui ui(client, poller);
+    agpm::Tui ui(client, poller, opts.log_limit);
     poller.start();
     try {
       ui.init();

--- a/src/tui.cpp
+++ b/src/tui.cpp
@@ -22,12 +22,8 @@
 
 namespace agpm {
 
-namespace {
-constexpr std::size_t kMaxLogs = 200;
-} // namespace
-
-Tui::Tui(GitHubClient &client, GitHubPoller &poller)
-    : client_(client), poller_(poller) {
+Tui::Tui(GitHubClient &client, GitHubPoller &poller, std::size_t log_limit)
+    : client_(client), poller_(poller), log_limit_(log_limit) {
   open_cmd_ = [](const std::string &url) {
 #if defined(_WIN32)
     std::string cmd = "start \"\" \"" + url + "\"";
@@ -80,8 +76,8 @@ void Tui::update_prs(const std::vector<PullRequest> &prs) {
 
 void Tui::log(const std::string &msg) {
   logs_.push_back(msg);
-  if (logs_.size() > kMaxLogs) {
-    logs_.erase(logs_.begin(), logs_.begin() + (logs_.size() - kMaxLogs));
+  if (logs_.size() > log_limit_) {
+    logs_.erase(logs_.begin(), logs_.begin() + (logs_.size() - log_limit_));
   }
 }
 

--- a/tests/test_cli.cpp
+++ b/tests/test_cli.cpp
@@ -36,10 +36,17 @@ TEST_CASE("test cli") {
   agpm::CliOptions opts4b = agpm::parse_cli(3, argv4b);
   REQUIRE(opts4b.log_file == "app.log");
 
+  char log_limit_flag[] = "--log-limit";
+  char log_limit_val[] = "123";
+  char *argv4c[] = {prog, log_limit_flag, log_limit_val};
+  agpm::CliOptions opts4c = agpm::parse_cli(3, argv4c);
+  REQUIRE(opts4c.log_limit == 123);
+
   char *argv5[] = {prog};
   agpm::CliOptions opts5 = agpm::parse_cli(1, argv5);
   REQUIRE(opts5.log_level == "info");
   REQUIRE(!opts5.include_merged);
+  REQUIRE(opts5.log_limit == 200);
 
   char include_flag[] = "--include";
   char repo_a[] = "repoA";

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -86,7 +86,7 @@ TEST_CASE("test main") {
   poller.stop();
   REQUIRE(count > 0);
 
-  agpm::Tui ui(client, poller);
+  agpm::Tui ui(client, poller, 200);
   ui.init();
   ui.cleanup();
 

--- a/tests/test_tui.cpp
+++ b/tests/test_tui.cpp
@@ -64,10 +64,11 @@ TEST_CASE("test tui") {
   MockHttpClient *raw = mock.get();
   GitHubClient client({"token"}, std::unique_ptr<HttpClient>(mock.release()));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 200);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
 

--- a/tests/test_tui_details.cpp
+++ b/tests/test_tui_details.cpp
@@ -48,10 +48,11 @@ TEST_CASE("tui show details") {
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 200);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
   ui.update_prs({{1, "PR title", false, "o", "r"}});
@@ -75,10 +76,11 @@ TEST_CASE("tui show details enter") {
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 200);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
   ui.update_prs({{2, "Another", false, "o", "r"}});

--- a/tests/test_tui_log_limit.cpp
+++ b/tests/test_tui_log_limit.cpp
@@ -58,10 +58,11 @@ TEST_CASE("test tui log limit") {
   mock->put_response = "{\"merged\":true}";
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 100);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
 
@@ -70,7 +71,8 @@ TEST_CASE("test tui log limit") {
     ui.handle_key('m');
   }
 
-  REQUIRE(ui.logs().size() == 200);
-  REQUIRE(ui.logs().front().find("Merged PR #5") != std::string::npos);
+  REQUIRE(ui.logs().size() == 100);
+  REQUIRE(ui.logs().front().find("Merged PR #105") != std::string::npos);
   REQUIRE(ui.logs().back().find("Merged PR #204") != std::string::npos);
+  ui.cleanup();
 }

--- a/tests/test_tui_merge.cpp
+++ b/tests/test_tui_merge.cpp
@@ -60,10 +60,11 @@ TEST_CASE("test tui merge") {
   MockHttpClient *raw = mock.get();
   GitHubClient client({"token"}, std::unique_ptr<HttpClient>(mock.release()));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 200);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
 

--- a/tests/test_tui_open.cpp
+++ b/tests/test_tui_open.cpp
@@ -48,10 +48,11 @@ TEST_CASE("tui open pr") {
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 200);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
   ui.update_prs({{1, "PR", false, "o", "r"}});

--- a/tests/test_tui_resize.cpp
+++ b/tests/test_tui_resize.cpp
@@ -47,10 +47,11 @@ TEST_CASE("test tui resize") {
   auto mock = std::make_unique<MockHttpClient>();
   GitHubClient client({"token"}, std::move(mock));
   GitHubPoller poller(client, {{"o", "r"}}, 1000, 60);
-  Tui ui(client, poller);
+  Tui ui(client, poller, 200);
   ui.init();
   if (!ui.initialized()) {
     WARN("Skipping TUI test: no TTY available");
+    ui.cleanup();
     return;
   }
 


### PR DESCRIPTION
## Summary
- add `--log-limit` CLI option and wiring through CliOptions
- allow TUI to receive a log limit value instead of using constant
- test that custom log limit is respected

## Testing
- `ctest --preset vcpkg --output-on-failure` *(fails: test_poller_branch, test_github_client_delay, test_history)*


------
https://chatgpt.com/codex/tasks/task_e_68b730b6d3a08325ba5be1a6eb63184d