### PR TITLE
fix: restore GitHubPoller arg order

### DIFF
--- a/include/github_poller.hpp
+++ b/include/github_poller.hpp
@@ -27,7 +27,6 @@ public:
    * @param only_poll_prs When true, skip branch polling
    * @param only_poll_stray When true, only poll branches for stray detection
    * @param reject_dirty Automatically close or delete dirty branches
-   * @param delete_stray Delete stray branches without requiring a prefix
    * @param purge_prefix Delete merged branches starting with this prefix
    * @param auto_merge Automatically merge qualifying pull requests
    * @param purge_only Only purge branches without polling PRs
@@ -36,19 +35,21 @@ public:
    * @param protected_branches Glob patterns for branches that must not be
    *        removed
    * @param protected_branch_excludes Patterns that override protections
+   * @param delete_stray Delete stray branches without requiring a prefix
    */
   GitHubPoller(GitHubClient &client,
                std::vector<std::pair<std::string, std::string>> repos,
                int interval_ms, int max_rate, int workers = 1,
                bool only_poll_prs = false, bool only_poll_stray = false,
-               bool reject_dirty = false, bool delete_stray = false,
-               std::string purge_prefix = "", bool auto_merge = false,
-               bool purge_only = false, std::string sort_mode = "",
+               bool reject_dirty = false, std::string purge_prefix = "",
+               bool auto_merge = false, bool purge_only = false,
+               std::string sort_mode = "",
                PullRequestHistory *history = nullptr,
                std::vector<std::string> protected_branches = {},
                std::vector<std::string> protected_branch_excludes = {},
                bool dry_run = false,
-               GitHubGraphQLClient *graphql_client = nullptr);
+               GitHubGraphQLClient *graphql_client = nullptr,
+               bool delete_stray = false);
 
   /// Start polling in a background thread.
   void start();

--- a/src/github_poller.cpp
+++ b/src/github_poller.cpp
@@ -10,11 +10,11 @@ GitHubPoller::GitHubPoller(
     GitHubClient &client,
     std::vector<std::pair<std::string, std::string>> repos, int interval_ms,
     int max_rate, int workers, bool only_poll_prs, bool only_poll_stray,
-    bool reject_dirty, bool delete_stray, std::string purge_prefix,
-    bool auto_merge, bool purge_only, std::string sort_mode,
-    PullRequestHistory *history, std::vector<std::string> protected_branches,
+    bool reject_dirty, std::string purge_prefix, bool auto_merge,
+    bool purge_only, std::string sort_mode, PullRequestHistory *history,
+    std::vector<std::string> protected_branches,
     std::vector<std::string> protected_branch_excludes, bool dry_run,
-    GitHubGraphQLClient *graphql_client)
+    GitHubGraphQLClient *graphql_client, bool delete_stray)
     : client_(client), repos_(std::move(repos)), poller_(workers, max_rate),
       interval_ms_(interval_ms), only_poll_prs_(only_poll_prs),
       only_poll_stray_(only_poll_stray), reject_dirty_(reject_dirty),

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -93,9 +93,9 @@ int main(int argc, char **argv) {
     bool only_poll_prs = opts.only_poll_prs || cfg.only_poll_prs();
     bool only_poll_stray = opts.only_poll_stray || cfg.only_poll_stray();
     bool reject_dirty = opts.reject_dirty || cfg.reject_dirty();
-    bool delete_stray = opts.delete_stray; // no config support yet
     std::string purge_prefix =
         !opts.purge_prefix.empty() ? opts.purge_prefix : cfg.purge_prefix();
+    bool delete_stray = opts.delete_stray; // no config support yet
     bool auto_merge = opts.auto_merge || cfg.auto_merge();
     bool purge_only = opts.purge_only || cfg.purge_only();
     std::string sort_mode = !opts.sort.empty() ? opts.sort : cfg.sort_mode();
@@ -120,10 +120,11 @@ int main(int argc, char **argv) {
 
     agpm::GitHubPoller poller(
         client, repos, interval_ms, max_rate, workers, only_poll_prs,
-        only_poll_stray, reject_dirty, delete_stray, purge_prefix, auto_merge,
-        purge_only, sort_mode, &history, protected_branches,
-        protected_branch_excludes, opts.dry_run,
-        (opts.use_graphql || cfg.use_graphql()) ? &graphql_client : nullptr);
+        only_poll_stray, reject_dirty, purge_prefix, auto_merge, purge_only,
+        sort_mode, &history, protected_branches, protected_branch_excludes,
+        opts.dry_run,
+        (opts.use_graphql || cfg.use_graphql()) ? &graphql_client : nullptr,
+        delete_stray);
 
     if (!opts.export_csv.empty() || !opts.export_json.empty()) {
       poller.set_export_callback([&history, &opts]() {


### PR DESCRIPTION
## Summary
- move `delete_stray` parameter to the end of `GitHubPoller` constructor
- update main poller construction for reordered arguments

## Testing
- `bash scripts/build_linux.sh` *(fails: VCPKG_ROOT not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b7688145a88325ae78ccadc208896b