### PR TITLE
fix: restore Windows and macOS notifications

### DIFF
--- a/include/notification.hpp
+++ b/include/notification.hpp
@@ -22,9 +22,13 @@ public:
 };
 
 /**
- * Basic notifier that uses the `notify-send` command on Linux desktops.
+ * Desktop notifier that invokes platform-specific utilities:
  *
- * Other platforms simply ignore notifications.
+ * - Linux: `notify-send`
+ * - Windows: BurntToast PowerShell module
+ * - macOS: `terminal-notifier` (preferred) or `osascript`
+ *
+ * If the required tool is not available, the notification request is ignored.
  */
 class NotifySendNotifier : public Notifier {
 public:

--- a/src/notification.cpp
+++ b/src/notification.cpp
@@ -21,13 +21,57 @@ std::string shell_escape(const std::string &s) {
   return out;
 }
 
+std::string escape_apple_script(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    if (c == '\\' || c == '"') {
+      out.push_back('\\');
+    }
+    out.push_back(c);
+  }
+  return out;
+}
+
+std::string escape_powershell(const std::string &s) {
+  std::string out;
+  out.reserve(s.size());
+  for (char c : s) {
+    if (c == '\'') {
+      out += "''";
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
 } // namespace
 
 NotifySendNotifier::NotifySendNotifier(CommandRunner runner)
     : run_(std::move(runner)) {}
 
 void NotifySendNotifier::notify(const std::string &message) {
-#if defined(__linux__)
+#ifdef _WIN32
+  std::string cmd =
+      "powershell -NoProfile -Command \"Try {Import-Module BurntToast "
+      "-ErrorAction Stop; New-BurntToastNotification -Text "
+      "'autogithubpullmerge','" +
+      escape_powershell(message) + "'} Catch {}\"";
+  run_(cmd);
+#elif defined(__APPLE__)
+  if (run_("command -v terminal-notifier >/dev/null 2>&1") == 0) {
+    std::string cmd =
+        "terminal-notifier -title 'autogithubpullmerge' -message " +
+        shell_escape(message);
+    run_(cmd);
+  } else {
+    std::string cmd = "osascript -e 'display notification \"" +
+                      escape_apple_script(message) +
+                      "\" with title \"autogithubpullmerge\"'";
+    run_(cmd);
+  }
+#elif defined(__linux__)
   if (run_("command -v notify-send >/dev/null 2>&1") == 0) {
     std::string cmd = "notify-send " + shell_escape("autogithubpullmerge") +
                       " " + shell_escape(message);

--- a/tests/test_notification.cpp
+++ b/tests/test_notification.cpp
@@ -18,8 +18,42 @@ TEST_CASE("NotifySendNotifier runs notify-send on Linux") {
 #endif
 }
 
-TEST_CASE("NotifySendNotifier does nothing on non-Linux") {
-#ifndef __linux__
+TEST_CASE("NotifySendNotifier uses BurntToast on Windows") {
+#ifdef _WIN32
+  std::vector<std::string> cmds;
+  NotifySendNotifier notifier([&](const std::string &cmd) {
+    cmds.push_back(cmd);
+    return 0;
+  });
+  notifier.notify("hello world");
+  REQUIRE(cmds.size() == 1);
+  CHECK(cmds[0] == "powershell -NoProfile -Command \"Try {Import-Module "
+                   "BurntToast -ErrorAction Stop; "
+                   "New-BurntToastNotification -Text "
+                   "'autogithubpullmerge','hello world'} Catch {}\"");
+#endif
+}
+
+TEST_CASE("NotifySendNotifier prefers terminal-notifier on macOS") {
+#ifdef __APPLE__
+  std::vector<std::string> cmds;
+  NotifySendNotifier notifier([&](const std::string &cmd) {
+    cmds.push_back(cmd);
+    if (cmd.find("command -v terminal-notifier") != std::string::npos) {
+      return 0; // simulate presence of terminal-notifier
+    }
+    return 0;
+  });
+  notifier.notify("hello world");
+  REQUIRE(cmds.size() == 2);
+  CHECK(
+      cmds[1] ==
+      "terminal-notifier -title 'autogithubpullmerge' -message 'hello world'");
+#endif
+}
+
+TEST_CASE("NotifySendNotifier does nothing on unsupported platforms") {
+#if !defined(_WIN32) && !defined(__APPLE__) && !defined(__linux__)
   bool called = false;
   NotifySendNotifier notifier([&](const std::string &) {
     called = true;


### PR DESCRIPTION
## Summary
- restore PowerShell and macOS notifier commands in `NotifySendNotifier`
- document platform-specific notification utilities
- expand notification tests for Windows and macOS

## Testing
- `cmake -S . -B build` *(fails: Vcpkg toolchain file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b818c8cd00832581e8257bb7b6d533