### PR TITLE
Handle PR cutoff using updated timestamps

### DIFF
--- a/docs/usage_summary.md
+++ b/docs/usage_summary.md
@@ -117,7 +117,8 @@ In configuration files, use the `repo_discovery_mode` key with values
   when `--retry-rate-limit-endpoint` is supplied (default `3`).
 - `--pr-limit` - limit how many pull requests to fetch when listing.
 - `--pr-since` - only list pull requests newer than the given duration
-  (e.g. `30m`, `2h`, `1d`).
+  (e.g. `30m`, `2h`, `1d`). The comparison uses each pull request's
+  `updated_at` timestamp when available and falls back to `created_at`.
 - `--only-poll-prs` - only poll pull requests.
 - `--only-poll-stray` - only poll stray branches.
 - `--stray-detection-engine` - select `rule`, `heuristic`, or `both` for stray

--- a/src/github_client.cpp
+++ b/src/github_client.cpp
@@ -997,9 +997,22 @@ GitHubClient::list_pull_requests(const std::string &owner,
       break;
     }
     for (const auto &item : j) {
+      auto read_timestamp = [](const nlohmann::json &object,
+                               const char *field) -> std::optional<std::string> {
+        if (object.contains(field) && object[field].is_string()) {
+          std::string value = object[field].get<std::string>();
+          if (!value.empty()) {
+            return value;
+          }
+        }
+        return std::nullopt;
+      };
       std::string ts;
-      if (item.contains("created_at"))
-        ts = item["created_at"].get<std::string>();
+      if (auto updated = read_timestamp(item, "updated_at")) {
+        ts = *updated;
+      } else if (auto created = read_timestamp(item, "created_at")) {
+        ts = *created;
+      }
       std::tm tm{};
       std::chrono::system_clock::time_point created =
           std::chrono::system_clock::now();

--- a/tests/test_github_client.cpp
+++ b/tests/test_github_client.cpp
@@ -130,14 +130,15 @@ public:
     if (calls == 1) {
       std::string body =
           "[{\"number\":1,\"title\":\"Old\",\"created_at\":\"" + old_ts +
-          "\"},{\"number\":2,\"title\":\"New\",\"created_at\":\"" + recent1_ts +
-          "\"}]";
+          "\",\"updated_at\":\"" + old_ts +
+          "\"},{\"number\":2,\"title\":\"New\",\"created_at\":\"" + old_ts +
+          "\",\"updated_at\":\"" + recent1_ts + "\"}]";
       std::string next =
           url + (url.find('?') == std::string::npos ? "?" : "&") + "page=2";
       return {body, {"Link: <" + next + ">; rel=\"next\""}, 200};
     }
     std::string body = "[{\"number\":3,\"title\":\"Newer\",\"created_at\":\"" +
-                       recent2_ts + "\"}]";
+                       recent2_ts + "\",\"updated_at\":\"" + recent2_ts + "\"}]";
     return {body, {}, 200};
   }
 

--- a/tests/test_pr_since.cpp
+++ b/tests/test_pr_since.cpp
@@ -33,20 +33,21 @@ public:
 TEST_CASE("test pr since") {
   using namespace std::chrono;
   auto now = system_clock::now();
-  auto recent = now - minutes(30);
+  auto recent_update = now - minutes(30);
   auto old = now - hours(5);
-  auto recent_t = system_clock::to_time_t(recent);
+  auto recent_update_t = system_clock::to_time_t(recent_update);
   auto old_t = system_clock::to_time_t(old);
-  char recent_buf[32];
+  char recent_update_buf[32];
   char old_buf[32];
-  std::strftime(recent_buf, sizeof(recent_buf), "%Y-%m-%dT%H:%M:%SZ",
-                std::gmtime(&recent_t));
+  std::strftime(recent_update_buf, sizeof(recent_update_buf),
+                "%Y-%m-%dT%H:%M:%SZ", std::gmtime(&recent_update_t));
   std::strftime(old_buf, sizeof(old_buf), "%Y-%m-%dT%H:%M:%SZ",
                 std::gmtime(&old_t));
   std::string resp =
       std::string("[{\"number\":1,\"title\":\"Old\",\"created_at\":\"") +
-      old_buf + "\"},{\"number\":2,\"title\":\"New\",\"created_at\":\"" +
-      recent_buf + "\"}]";
+      old_buf +
+      "\"},{\"number\":2,\"title\":\"Reopened\",\"created_at\":\"" +
+      old_buf + "\",\"updated_at\":\"" + recent_update_buf + "\"}]";
   auto http = std::make_unique<TimeHttpClient>();
   http->response = resp;
   GitHubClient client({"tok"}, std::unique_ptr<HttpClient>(http.release()));


### PR DESCRIPTION
## Summary
- use the pull request updated_at timestamp when evaluating the --pr-since cutoff
- expand list_pull_requests unit coverage to keep PRs that were updated recently and adjust docs

## Testing
- cmake --preset vcpkg *(fails: Vcpkg toolchain file not found in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_6901133ab9f48325bb1c572eed736291